### PR TITLE
feat: local file watching with notify-rs for external editor sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stik",
-  "version": "0.7.2",
+  "version": "0.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stik",
-      "version": "0.7.2",
+      "version": "0.7.8",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.0",
         "@codemirror/lang-markdown": "^6.3.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -988,6 +988,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1854,12 +1863,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1998,6 +2036,26 @@ dependencies = [
  "bitflags 2.10.0",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -2194,6 +2252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -2276,6 +2335,34 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.10.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "num-conv"
@@ -4043,7 +4130,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stik"
-version = "0.7.5"
+version = "0.7.8"
 dependencies = [
  "aes-gcm",
  "arboard",
@@ -4053,6 +4140,7 @@ dependencies = [
  "flate2",
  "glib 0.21.5",
  "image",
+ "notify",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,6 +36,7 @@ flate2 = "1"
 prost = "0.13"
 aes-gcm = "0.10"
 rand = "0.8"
+notify = "7"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = "3"

--- a/src-tauri/src/commands/file_watcher.rs
+++ b/src-tauri/src/commands/file_watcher.rs
@@ -1,0 +1,96 @@
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::sync::mpsc;
+use tauri::{AppHandle, Emitter, Manager};
+
+use super::embeddings::{self, EmbeddingIndex};
+use super::index::NoteIndex;
+use super::notes;
+use super::storage;
+
+pub fn start_watching(app: AppHandle) -> Result<(), String> {
+    let root = storage::stik_root()?;
+
+    let (tx, rx) = mpsc::channel::<notify::Result<Event>>();
+
+    let mut watcher = RecommendedWatcher::new(tx, notify::Config::default())
+        .map_err(|e| e.to_string())?;
+
+    watcher
+        .watch(&root, RecursiveMode::Recursive)
+        .map_err(|e| e.to_string())?;
+
+    // Keep watcher alive for the duration of the loop; dropping it closes the channel.
+    let _watcher = watcher;
+
+    let debounce = std::time::Duration::from_millis(500);
+
+    loop {
+        let first = match rx.recv() {
+            Ok(ev) => ev,
+            Err(_) => break,
+        };
+
+        let mut batch = vec![first];
+
+        // Drain any events that arrive within the debounce window
+        let deadline = std::time::Instant::now() + debounce;
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match rx.recv_timeout(remaining) {
+                Ok(ev) => batch.push(ev),
+                Err(_) => break,
+            }
+        }
+
+        let mut changed_paths: Vec<String> = batch
+            .into_iter()
+            .filter_map(|res| res.ok())
+            .filter(|ev| {
+                matches!(
+                    ev.kind,
+                    EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+                )
+            })
+            .flat_map(|ev| ev.paths)
+            .filter(|p| {
+                p.extension()
+                    .and_then(|e| e.to_str())
+                    .map(|e| e.eq_ignore_ascii_case("md"))
+                    .unwrap_or(false)
+            })
+            .filter(|p| {
+                let s = p.to_string_lossy();
+                !s.contains("/.git/") && !s.contains("/.assets/")
+            })
+            .map(|p| p.to_string_lossy().to_string())
+            .collect();
+
+        changed_paths.dedup();
+
+        if changed_paths.is_empty() {
+            continue;
+        }
+
+        let index = app.state::<NoteIndex>();
+        index.notify_external_change(&changed_paths);
+
+        let emb = app.state::<EmbeddingIndex>();
+        for path_str in &changed_paths {
+            if let Ok(content) = storage::read_file(path_str) {
+                if !notes::is_effectively_empty_markdown(&content) {
+                    if let Some(embedding) = embeddings::embed_content(&content) {
+                        emb.add_entry(path_str, embedding);
+                    }
+                }
+            }
+        }
+        let _ = emb.save();
+
+        let _ = app.emit("icloud-files-changed", &changed_paths);
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod apple_notes;
 pub mod cursor_positions;
 pub mod darwinkit;
 pub mod embeddings;
+pub mod file_watcher;
 pub mod folders;
 pub mod git_share;
 pub mod icloud;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,7 +10,7 @@ mod windows;
 use commands::embeddings::EmbeddingIndex;
 use commands::index::NoteIndex;
 use commands::{
-    ai_assistant, analytics, apple_notes, cursor_positions, darwinkit, embeddings,
+    ai_assistant, analytics, apple_notes, cursor_positions, darwinkit, embeddings, file_watcher,
     folders, git_share, icloud, index, note_lock, notes, on_this_day, settings, share,
     stats, sticked_notes, storage,
 };
@@ -248,6 +248,19 @@ fn main() {
                     eprintln!("Failed to build note index: {}", e);
                 }
             }
+            // Start local file watcher for non-iCloud modes
+            if !settings.icloud.enabled {
+                let watcher_handle = app.handle().clone();
+                std::thread::Builder::new()
+                    .name("stik-file-watcher".to_string())
+                    .spawn(move || {
+                        if let Err(e) = file_watcher::start_watching(watcher_handle) {
+                            eprintln!("Failed to start file watcher: {}", e);
+                        }
+                    })
+                    .ok();
+            }
+
             shortcuts::register_shortcuts_from_settings(app.handle(), &settings);
             analytics::start_analytics(app.handle());
 

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -326,6 +326,16 @@ export default function CommandPalette() {
     }
   }, [loadFolderStats, query, selectedFolder]);
 
+  // Refresh when external file changes are detected (e.g. edits from Obsidian)
+  useEffect(() => {
+    const unlisten = listen("icloud-files-changed", () => {
+      refreshAfterChange();
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [refreshAfterChange]);
+
   // Delete note
   const handleDeleteNote = useCallback(
     async (note: SearchResult) => {

--- a/src/components/PostIt.tsx
+++ b/src/components/PostIt.tsx
@@ -320,6 +320,30 @@ export default function PostIt({
     };
   }, [isViewing, originalPath, currentStickedId, stickedId]);
 
+  // Reload content when file changes externally (e.g. edited in Obsidian)
+  useEffect(() => {
+    if (!originalPath) return;
+
+    const unlisten = listen<string[]>("icloud-files-changed", async (event) => {
+      const changedPaths = event.payload;
+      if (changedPaths.includes(originalPath)) {
+        try {
+          const newContent = await invoke<string>("get_note_content", { path: originalPath });
+          if (newContent !== content) {
+            setContent(newContent);
+            editorRef.current?.setContent(newContent);
+          }
+        } catch (err) {
+          console.error("Failed to reload externally changed note:", err);
+        }
+      }
+    });
+
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [originalPath, content]);
+
   // Focus editor on mount, when folder changes, or when editor becomes available after settings load
   useEffect(() => {
     if (vimEnabled === null) return; // editor not mounted yet


### PR DESCRIPTION
## Summary
- notify-rs v7로 로컬/Custom 모드에서 Stik 노트 디렉토리 파일 감시 추가
- 외부 에디터(Obsidian 등)에서 .md 파일 수정 시 자동으로 노트 인덱스/임베딩 업데이트 + 프론트엔드 새로고침
- 열려있는 노트의 내용도 자동 갱신 (PostIt 컴포넌트)

## Test plan
- [x] 파일 워처 시작 확인 (stderr 로그로 검증)
- [x] 외부에서 .md 파일 수정 시 변경 감지 확인
- [x] 프론트엔드 이벤트 발행 및 노트 목록 새로고침 확인
- [x] Obsidian에서 수정 → Stik에서 즉시 반영 확인
- [ ] iCloud 모드에서 워처가 시작되지 않는지 확인
- [ ] Stik 루트 디렉토리 없을 때 graceful 에러 처리

🤖 Generated with [Claude Code](https://claude.com/claude-code)