### PR TITLE
docs(roadmap): sync with reality and add v0.9 hardening phase

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,10 +1,15 @@
 # Roadmap
 
-> Current version: 0.5.0
+> Current version: **0.8.0**
+
+Stik ships when a phase is useful, not when it is complete. Items are moved to
+✅ only when they are on `main` and released — not when a branch exists.
 
 ---
 
-## Phase 1 — Core Capture (v0.1.0) ✅
+## Shipped
+
+### Phase 1 — Core Capture (v0.1.0) ✅
 
 - [x] Global shortcut to summon floating post-it window
 - [x] Type, close, note saved as markdown in `~/Documents/Stik/`
@@ -13,10 +18,10 @@
 - [x] Manager modal (browse, delete, rename, move notes)
 - [x] Pin notes as floating sticky notes on desktop
 - [x] Configurable shortcuts for every action
-- [x] Rich text editing with markdown support (Tiptap)
+- [x] Rich text editing with markdown support
 - [x] System tray with quick actions
 
-## Phase 2 — Stability & Security (v0.2.0) ✅
+### Phase 2 — Stability & Security (v0.2.0) ✅
 
 - [x] In-memory note index for fast search
 - [x] On-demand content loading (lightweight IPC)
@@ -26,9 +31,9 @@
 - [x] Scoped filesystem permissions
 - [x] Atomic file writes (prevent data corruption)
 - [x] Mutex recovery (prevent crashes)
-- [x] Architecture refactor (split main.rs into focused modules)
+- [x] Architecture refactor (split `main.rs` into focused modules)
 
-## Phase 3 — On-Device AI & Sharing (v0.3.0) ✅
+### Phase 3 — On-Device AI & Sharing (v0.3.0) ✅
 
 - [x] DarwinKit sidecar — Swift CLI exposing Apple NaturalLanguage framework
 - [x] Semantic search (hybrid text + vector similarity with badges)
@@ -36,11 +41,11 @@
 - [x] Language-aware embeddings (per-language vector spaces)
 - [x] Git-based folder sharing (background auto-sync)
 - [x] Capture streak (consecutive-day counter)
-- [x] "On This Day" resurfacing (daily notification from past years)
+- [x] "On This Day" resurfacing
 - [x] Share as clipboard (rich text, markdown, or image)
 - [x] Settings redesign (Raycast-style tab layout)
 
-## Phase 4 — Polish & Power Features (v0.4.x) ✅
+### Phase 4 — Polish & Power Features (v0.4.x) ✅
 
 - [x] Vim mode
 - [x] Wiki-links between notes
@@ -48,38 +53,119 @@
 - [x] Custom keyboard shortcuts
 - [x] Folder-scoped search
 
-## Phase 5 — Power Capture (v0.5.0)
+### Phase 5 — Power Capture (v0.5.0 – v0.8.0) — partially shipped
 
-- [ ] Voice capture via global shortcut (push-to-talk, on-device transcription via Apple Speech)
-- [ ] Screenshot OCR capture (select screen region → extract text → save as note)
-- [ ] Capture from any app (highlight text anywhere → shortcut → note with source URL)
-- [ ] Inline slash commands (`/date`, `/todo`, `/tag`, `/divider`)
-- [ ] Note templates (daily note, meeting, idea, custom)
-- [ ] Inline tags (`#tag`) with tag-based filtering and search
-- [ ] Shelf mode (temporary notes that auto-archive after X days if not saved)
+- [x] Note templates (daily note, meeting, idea, custom)
+- [x] Inline slash commands (`/date`, `/todo`, `/tag`, `/divider`)
+- [x] Voice capture via global shortcut (`⌘⇧D`, on-device WhisperKit) — v0.8.0
+- [x] Capture from any app — clip capture `⌘⇧C` via Accessibility API — v0.8.0
+- [x] Note locking (AES-256-GCM + Touch ID) — v0.7.6
+- [x] iCloud Drive sync — v0.7.6
+- [x] Local file watching / external change detection — v0.7.9
+- [ ] **Screenshot OCR capture** (select region → extract text → note) — not started
+- [ ] **Inline tags** (`#tag`) with tag-based filtering and search — not started
+- [ ] **Shelf mode** (temporary notes that auto-archive after X days) — not started
 
-## Phase 6 — Knowledge Graph (v0.6.0)
+### Phase 6 — Knowledge Graph — started early
 
+- [x] Apple Foundation Models integration (on-device LLM: rephrase, summarize, organize)
 - [ ] Backlinks panel ("notes linking to this note")
 - [ ] Graph view of note connections (wiki-links visualization)
 - [ ] Daily digest notification (AI summary of captured thoughts)
-- [ ] Smart resurfacing (context-aware suggestions, not just "On This Day")
-- [ ] Apple Foundation Models integration (on-device LLM for summarization, auto-tagging, note cleanup)
+- [ ] Smart resurfacing (context-aware, not just "On This Day")
 
-## Phase 7 — Ecosystem (v0.7.0)
+### Phase 7 — Ecosystem
 
-- [ ] Raycast extension (capture to Stik from Raycast)
-- [ ] CLI/API for scripting (`stik capture "text"` from terminal)
-- [ ] PKM integration (folder aliasing to Obsidian vaults, Logseq, etc.)
+- [x] Raycast extension (`0xMassi/stik-raycast`)
+- [x] Internationalization foundation + Simplified Chinese (v0.9.0-dev)
+- [ ] CLI/API for scripting (`stik capture "text"`)
+- [ ] PKM integration (folder aliasing to Obsidian vaults, Logseq)
 - [ ] Export rules (trigger-based actions on note save)
 - [ ] Alfred extension
 
-## Phase 8 — Mobile & Sync (v1.0)
+### Phase 8 — Mobile & Sync (v1.0)
 
-- [ ] iOS companion app (capture + read, via iCloud initially)
-- [ ] E2E encrypted cloud sync (optional, paid — S3 + Cognito + KMS)
+- [ ] iOS companion app (capture + read, via iCloud initially) — in progress
+- [ ] E2E encrypted cloud sync (optional, paid)
 - [ ] Cross-device conflict resolution
-- [ ] Zero-knowledge architecture (AWS as encrypted storage, keys never leave device)
+- [ ] Zero-knowledge architecture
+- [ ] Android companion — see [Discussion #68](https://github.com/0xMassi/stik_app/discussions/68)
+
+---
+
+## v0.9 — Hardening
+
+Stik is at the point where feature velocity is outrunning its safety net. This
+phase is deliberately unglamorous: it exists so 1.0 can be trusted.
+
+### Blocking for 0.9
+
+- [ ] **CI on pull requests.** `release.yml` only fires on `v*` tags, so nothing
+      runs `cargo test` / `npm test` on a PR or on a push to `main`. Every
+      Dependabot PR merges with "no checks reported" and regressions are only
+      caught by hand. This is the single highest-value fix in the repo.
+- [ ] **`.github/dependabot.yml`.** Only *security* updates arrive today
+      (GitHub's default). Routine version updates are never proposed, so the
+      dependency tree drifts until an advisory forces a jump.
+- [ ] **Finish the i18n migration.** ~190 strings are still hardcoded English,
+      ~133 of them in `SettingsContent.tsx`. The foundation shipped; the
+      settings surface — the part a non-English speaker most needs — has not.
+- [ ] **Translate backend-generated strings.** Capture-streak labels and
+      "On This Day" messages are formatted in `stats.rs` / `on_this_day.rs` and
+      reach the UI pre-rendered in English. They need to return structured data
+      (counts, dates) and let the frontend format.
+
+### Test coverage
+
+Current: 100 frontend tests, 62 Rust tests — but concentrated in pure helpers.
+
+- [ ] **No component tests exist.** All 24 frontend test files cover
+      `utils/` and `extensions/`. `PostIt`, `CommandPalette` and `SettingsContent`
+      — where the real behaviour lives — have none.
+- [ ] **13 of 23 Rust command modules have no tests**, including
+      `storage.rs` and `versioning.rs` (data integrity), `icloud.rs` (sync
+      correctness) and `embeddings.rs`. A migration bug here silently corrupts
+      user notes.
+- [ ] **No window-behaviour smoke test.** The v0.9 tauri bump moved
+      wry / tao / tray-icon a full minor each; `cargo test` proved nothing about
+      window creation, vibrancy, or the tray. A scripted launch-and-assert would
+      have.
+
+### Security & privacy
+
+- [ ] **Tighten CSP `img-src`.** It currently allows `https:` and `http:`
+      wholesale, so a remote image URL pasted into a note silently fetches on
+      render — leaking the reader's IP and enabling tracking pixels. For a
+      privacy-first, local-first app this is the sharpest inconsistency in the
+      codebase. Consider proxying remote images through the backend, or
+      requiring explicit per-note opt-in.
+- [ ] **Audit panic surface.** 15 `unwrap()` and 18 `expect()` outside tests.
+      In a Tauri command a panic takes down the webview, not just the call.
+- [ ] **Review 9 `unsafe` blocks** (objc2 / AppKit interop) and document the
+      invariant each one relies on.
+- [ ] Accepted, not actionable: `rand 0.7.3` (RUSTSEC low) arrives via
+      `phf_generator`, build-time only, and the advisory requires a custom
+      runtime logger.
+
+### Architecture
+
+- [ ] **`SettingsContent.tsx` is 3,069 lines** and `PostIt.tsx` is 2,065.
+      Both are past the point of comfortable review; splitting settings into
+      per-tab modules would also make the i18n migration tractable.
+- [ ] **`main.rs` has grown to 737 lines**, having been refactored down to a
+      thin orchestrator in Phase 2. The command registry and setup hook are the
+      bulk — worth re-splitting before it accretes further.
+- [ ] **Frontend ships a 1.19 MB chunk** (378 kB gzipped) with no code
+      splitting. Each of the five window types loads the whole bundle,
+      including CodeMirror language modes it will never use — directly at odds
+      with the sub-second-capture promise.
+
+### Repo hygiene
+
+- [ ] Delete merged branches — 7 stale refs on `origin`.
+- [ ] `feature/apple-notes-import` exists **only locally** with 2 unpushed
+      commits (direct Apple Notes SQLite read/write). It is one disk failure
+      from being lost — push it or fold it in.
 
 ---
 
@@ -93,4 +179,4 @@
 
 ---
 
-*Last updated: February 12, 2026*
+*Last updated: July 29, 2026*


### PR DESCRIPTION
The roadmap said **"Current version: 0.5.0"** while `main` ships **0.8.0**, and was last updated in February. This corrects it and adds a concrete v0.9 phase.

## Drift corrected

Shipped but never ticked: voice capture (`⌘⇧D`), clip capture (`⌘⇧C`), note templates, slash commands, note locking, iCloud sync, file watching. Foundation Models landed early from Phase 6; the Raycast extension from Phase 7.

Still genuinely not started in Phase 5: **screenshot OCR**, **inline tags**, **shelf mode**.

## New: v0.9 — Hardening

Feature velocity has outrun the safety net. Highlights:

**Process**
- **No CI on PRs.** `release.yml` fires only on `v*` tags, so nothing runs `cargo test` / `npm test` on a pull request or a push to `main`. Every Dependabot PR this cycle merged with *"no checks reported"*. Highest-value fix in the repo.
- **No `.github/dependabot.yml`** — only security updates arrive; routine version bumps never get proposed, so the tree drifts until an advisory forces a jump.

**Testing**
- **Zero component tests.** All 24 frontend test files cover `utils/` and `extensions/`; `PostIt`, `CommandPalette`, `SettingsContent` have none.
- **13 of 23 Rust command modules untested**, including `storage.rs` and `versioning.rs` — a migration bug there corrupts notes silently.

**Security & privacy**
- **CSP `img-src` allows `https:` and `http:` wholesale.** A remote image URL in a note fetches on render, leaking the reader's IP and enabling tracking pixels. For a local-first, privacy-first app this is the sharpest inconsistency in the codebase.
- 15 `unwrap()` + 18 `expect()` outside tests — a panic in a Tauri command takes the webview down.

**Architecture**
- `SettingsContent.tsx` at 3,069 lines; `main.rs` regrown to 737 (it was refactored to a thin orchestrator in Phase 2).
- 1.19 MB single chunk (378 kB gzipped), no code splitting — all five window types load the full bundle including unused CodeMirror language modes, against the sub-second-capture promise.

**Hygiene**
- 7 stale merged branches on `origin`.
- ⚠️ **`feature/apple-notes-import` exists only locally with 2 unpushed commits** (Apple Notes SQLite read/write). One disk failure from gone.

Docs-only change — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)