### PR TITLE
fix(beta): disable createUpdaterArtifacts so the build completes

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -6,8 +6,8 @@ name: Beta Build
 # sidecar layout.
 #
 # Deliberately NOT a release:
-#   - no `updater` bundle, so `latest.json` is never written and users on the
-#     stable channel are never offered a beta
+#   - createUpdaterArtifacts disabled, so no updater tarball is produced and
+#     `latest.json` is never written; stable users are never offered a beta
 #   - no Homebrew tap update
 #   - published as a GitHub *prerelease*, so it never shows as "Latest"
 #
@@ -76,6 +76,14 @@ jobs:
           d["productName"] = "Stik Beta"
           d["identifier"] = "com.stik.app.beta"
           d["version"] = os.environ["BETA_VERSION"]
+          # `--bundles app` does NOT suppress the updater tarball: bundle
+          # .createUpdaterArtifacts is "v1Compatible", which emits
+          # `Stik Beta.app.tar.gz (updater)` anyway and then fails the build
+          # with "A public key has been found, but no private key" because we
+          # deliberately withhold TAURI_SIGNING_PRIVATE_KEY from beta. Turning
+          # it off is what actually delivers the "no updater artifacts" the
+          # beta channel promises.
+          d.setdefault("bundle", {})["createUpdaterArtifacts"] = False
           # The updater plugin fails to *initialize* if plugins.updater is
           # absent ("invalid type: null, expected struct Config"), which kills
           # the app at startup — so the config has to stay. Instead point it at


### PR DESCRIPTION
Second failure on the beta pipeline, and this one was mine.

With notarization skipped, the build got past Apple and then died on:

```
A public key has been found, but no private key.
Make sure to set `TAURI_SIGNING_PRIVATE_KEY` environment variable.
```

## Cause

I assumed `--bundles app` suppresses updater output. It doesn't. `bundle.createUpdaterArtifacts` is `"v1Compatible"`, so tauri emits `Stik Beta.app.tar.gz (updater)` regardless of the requested bundle list — visible in the failing log — then tries to sign it with a key the beta workflow deliberately withholds.

So the previous PR's claim of "no updater artifacts" was wrong: they were being built, just not signable.

## Fix

Set `bundle.createUpdaterArtifacts = false` in the beta rebrand step. That's what actually delivers the isolation the beta channel promised.

**Verified locally** rather than assumed this time — bundling now finishes with:

```
Finished 1 bundle at:
    .../Stik Beta.app
```

versus the CI run, which also listed `.../Stik Beta.app.tar.gz (updater)`.

## This affected both paths

The notarized step never had `TAURI_SIGNING_PRIVATE_KEY` either — it would have hit the same error immediately after notarization once the Apple agreement is signed. Fixing it here unblocks both.

Also corrected the workflow header comment, which described `--bundles app` as the mechanism preventing updater artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)