### PR TITLE
docs: switch README badges to shieldcn.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/0xMassi/stik_app/releases/latest"><img src="https://img.shields.io/github/v/release/0xMassi/stik_app?style=flat-square&color=E8705F&v=1" alt="Latest release"></a>
-  <img src="https://img.shields.io/github/license/0xMassi/stik_app?style=flat-square&v=1" alt="License">
-  <img src="https://img.shields.io/badge/platform-macOS-000?style=flat-square&logo=apple&v=1" alt="macOS">
-  <a href="https://github.com/0xMassi/stik_app/releases"><img src="https://img.shields.io/github/downloads/0xMassi/stik_app/total?style=flat-square&color=E8705F&v=1" alt="Downloads"></a>
-  <a href="https://github.com/0xMassi/stik_app/stargazers"><img src="https://img.shields.io/github/stars/0xMassi/stik_app?style=flat-square&color=E8705F&v=1" alt="Stars"></a>
+  <a href="https://github.com/0xMassi/stik_app/releases/latest"><img src="https://shieldcn.dev/github/0xMassi/stik_app/release.svg?color=E8705F" alt="Latest release"></a>
+  <img src="https://shieldcn.dev/github/0xMassi/stik_app/license.svg" alt="License">
+  <img src="https://shieldcn.dev/badge/platform-macOS-000.svg?logo=apple" alt="macOS">
+  <a href="https://github.com/0xMassi/stik_app/releases"><img src="https://shieldcn.dev/github/downloads/0xMassi/stik_app.svg?color=E8705F" alt="Downloads"></a>
+  <a href="https://github.com/0xMassi/stik_app/stargazers"><img src="https://shieldcn.dev/github/0xMassi/stik_app/stars.svg?color=E8705F" alt="Stars"></a>
 </p>
 
 <p align="center">
@@ -34,7 +34,7 @@
 </p>
 
 <p align="center">
-  <a href="https://www.stik.ink/download?utm_source=github&utm_medium=readme&utm_campaign=hero_cta"><img src="https://img.shields.io/badge/Download_Stik_for_Mac-E8705F?style=for-the-badge&logo=apple&logoColor=white" alt="Download Stik for Mac"></a>
+  <a href="https://www.stik.ink/download?utm_source=github&utm_medium=readme&utm_campaign=hero_cta"><img src="https://shieldcn.dev/badge/Download_Stik_for_Mac-E8705F.svg?logo=apple&logoColor=white&size=lg" alt="Download Stik for Mac"></a>
 </p>
 
 ---


### PR DESCRIPTION
Swaps all six `img.shields.io` badges for [shieldcn.dev](https://shieldcn.dev) equivalents, and adds badges to the **darwinkit** README (which had none) — committed separately at [0xMassi/darwinkit@8c78781](https://github.com/0xMassi/darwinkit/commit/8c78781cc7b631f23075d8bcfa73eeff827cef0d).

## stik_app

| badge | endpoint |
|---|---|
| release | `/github/0xMassi/stik_app/release.svg?color=E8705F` |
| license | `/github/0xMassi/stik_app/license.svg` |
| platform | `/badge/platform-macOS-000.svg?logo=apple` |
| downloads | `/github/downloads/0xMassi/stik_app.svg?color=E8705F` |
| stars | `/github/0xMassi/stik_app/stars.svg?color=E8705F` |
| Download CTA | `/badge/Download_Stik_for_Mac-E8705F.svg?logo=apple&logoColor=white&size=lg` |

## darwinkit

License, stars, platform, language. **No release badge** — darwinkit has tags (`v0.3.2`) but zero GitHub *Releases*, so `/github/.../release` returns `{"error":"not found"}` and would have rendered broken.

## Verified, not assumed

The docs list `/static/{label}/{value}` and `/badge.json?label=...` but both return `{"error":"not found"}` — while still answering **200** for the `.svg` variant, so a naive HTTP check would have passed and shipped blank badges. The static badges therefore use the shields.io-compatible `/badge/{label}-{value}-{color}.svg` form.

Every URL was checked for a 200 *and* real data via the `.json` variant: release → `v0.8.0`, stars → `233`, darwinkit license → `MIT`.

Also dropped the `&v=1` cache-busters — they existed to force GitHub's camo CDN to re-fetch stale shields.io badges; the new URLs are cold in camo anyway.

## Trade-off

shields.io is long-established infrastructure; shieldcn.dev is comparatively new. This accepts a dependency on a smaller provider for the nicer style — if it ever goes down the badges break. One commit to revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)