### PR TITLE
fix(beta): import signing cert job-wide so DMG codesign finds it

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -55,6 +55,27 @@ jobs:
         with:
           workspaces: src-tauri
 
+      - name: Import Apple signing certificate
+        # tauri-action imports the cert into a keychain scoped to its own step,
+        # so the later `codesign` of the DMG finds nothing ("no identity
+        # found"). release.yml solves this with an explicit job-wide import;
+        # mirror it here.
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          CERT_PATH=$RUNNER_TEMP/certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain
+
+          echo "$APPLE_CERTIFICATE" | base64 --decode > "$CERT_PATH"
+
+          security create-keychain -p "" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -k "" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain
+
       - name: Compute beta version
         id: meta
         run: |


### PR DESCRIPTION
Third failure in the beta pipeline. The app builds now (previous two fixes held) — this one is the DMG step:

```
created: .../Stik-Beta_0.8.0-beta.5_aarch64.dmg
***: no identity found
```

`hdiutil` produced the DMG fine. `codesign --sign "$APPLE_SIGNING_IDENTITY"` then found no matching identity.

## Cause

`tauri-action` imports the certificate into a keychain scoped to **its own step**, so nothing remains in the keychain search list for later steps. My workflow leaned on that implicit import, which only ever covered tauri's own signing — not the DMG I package afterwards.

`release.yml` already solves this with an explicit *"Import Apple signing certificate"* step near the top of the job. beta.yml now mirrors it verbatim.

## Progress so far on this pipeline

| # | failure | cause | status |
|---|---|---|---|
| 1 | notarization 403 | Apple Developer agreement lapsed — **account-side, still outstanding** | worked around via `notarize=false` |
| 2 | no private key | `createUpdaterArtifacts: v1Compatible` emitted an updater tarball `--bundles app` doesn't suppress | fixed in #74 |
| 3 | no identity found | cert imported only inside tauri-action's step | this PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)