### PR TITLE
feat(settings): show a BETA pill and pre-release version

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -14,6 +14,7 @@ import type {
 } from "@/types";
 import { createCoalescedTaskRunner } from "@/utils/coalescedTaskRunner";
 import { useTranslation } from "@/hooks/useTranslation";
+import { channelLabel } from "@/utils/appChannel";
 import type { TranslationKey } from "@/i18n";
 import {
   SETTINGS_MODAL_MAX_WIDTH,
@@ -248,6 +249,7 @@ export default function SettingsModal({
   const [isSyncingGitNow, setIsSyncingGitNow] = useState(false);
   const [isOpeningGitRemote, setIsOpeningGitRemote] = useState(false);
   const [appVersion, setAppVersion] = useState("");
+  const betaLabel = channelLabel(appVersion);
 
   const waitForPaint = () =>
     new Promise<void>((resolve) => {
@@ -534,6 +536,14 @@ export default function SettingsModal({
               <h2 className="text-[15px] font-semibold text-ink">
                 {t("settings.title")}
               </h2>
+              {betaLabel && (
+                <span
+                  className="px-1.5 py-0.5 rounded-md bg-coral/15 text-coral text-[9px] font-bold tracking-wide"
+                  title={`${t("settings.betaBuild")} — v${appVersion}`}
+                >
+                  {betaLabel}
+                </span>
+              )}
             </div>
             <button
               type="button"
@@ -596,6 +606,14 @@ export default function SettingsModal({
               <h2 className="text-[15px] font-semibold text-ink">
                 {t("settings.title")}
               </h2>
+              {betaLabel && (
+                <span
+                  className="px-1.5 py-0.5 rounded-md bg-coral/15 text-coral text-[9px] font-bold tracking-wide"
+                  title={`${t("settings.betaBuild")} — v${appVersion}`}
+                >
+                  {betaLabel}
+                </span>
+              )}
             </div>
             <button
               type="button"

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -33,6 +33,7 @@ export const en = {
 
   // ── Settings — navigation ─────────────────────────────────────────
   "settings.title": "Settings",
+  "settings.betaBuild": "Beta build — not the stable release",
   "settings.tab.appearance": "Appearance",
   "settings.tab.shortcuts": "Shortcuts",
   "settings.tab.folders": "Folders",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -36,6 +36,7 @@ export const zhCN: Translations = {
 
   // ── Settings — navigation ─────────────────────────────────────────
   "settings.title": "设置",
+  "settings.betaBuild": "Beta 版本 — 并非稳定发布版",
   "settings.tab.appearance": "外观",
   "settings.tab.shortcuts": "快捷键",
   "settings.tab.folders": "文件夹",

--- a/src/utils/appChannel.test.ts
+++ b/src/utils/appChannel.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { channelFor, isPreRelease, channelLabel } from "./appChannel";
+
+describe("channelFor", () => {
+  it("treats a plain release version as stable", () => {
+    expect(channelFor("0.8.0")).toBe("stable");
+    expect(channelFor("1.0.0")).toBe("stable");
+  });
+
+  it("treats any SemVer pre-release as beta", () => {
+    expect(channelFor("0.8.0-beta.7")).toBe("beta");
+    expect(channelFor("0.9.0-rc.1")).toBe("beta");
+    expect(channelFor("1.0.0-alpha")).toBe("beta");
+  });
+
+  it("ignores build metadata when deciding", () => {
+    // `+sha` is build metadata, not a pre-release marker.
+    expect(channelFor("0.8.0+abc1234")).toBe("stable");
+    expect(channelFor("0.8.0-beta.7+abc1234")).toBe("beta");
+  });
+
+  it("falls back to stable for empty or whitespace input", () => {
+    // getVersion() is async; the version is "" on first render, and flashing
+    // a BETA pill on a stable build would be worse than showing it late.
+    expect(channelFor("")).toBe("stable");
+    expect(channelFor("   ")).toBe("stable");
+  });
+
+  it("treats a trailing dash with no identifier as stable", () => {
+    expect(channelFor("0.8.0-")).toBe("stable");
+  });
+});
+
+describe("isPreRelease", () => {
+  it("mirrors channelFor", () => {
+    expect(isPreRelease("0.8.0-beta.7")).toBe(true);
+    expect(isPreRelease("0.8.0")).toBe(false);
+  });
+});
+
+describe("channelLabel", () => {
+  it("returns BETA for pre-release builds", () => {
+    expect(channelLabel("0.8.0-beta.7")).toBe("BETA");
+  });
+
+  it("returns null on stable so nothing renders", () => {
+    expect(channelLabel("0.8.0")).toBeNull();
+    expect(channelLabel("")).toBeNull();
+  });
+});

--- a/src/utils/appChannel.ts
+++ b/src/utils/appChannel.ts
@@ -1,0 +1,32 @@
+/// Release-channel detection.
+///
+/// Beta builds are produced by `.github/workflows/beta.yml`, which stamps
+/// `tauri.conf.json` with a SemVer pre-release version (`0.8.0-beta.7`) and
+/// renames the app to "Stik Beta". The version string is the reliable signal:
+/// it is set by the workflow itself, whereas the product name could drift.
+
+export type ReleaseChannel = "stable" | "beta";
+
+/// SemVer pre-release: everything after the first `-`, before any `+` build
+/// metadata. `0.8.0-beta.7` → beta, `0.8.0` → stable.
+export function channelFor(version: string): ReleaseChannel {
+  const trimmed = version.trim();
+  if (!trimmed) return "stable";
+
+  const withoutBuild = trimmed.split("+")[0];
+  const dash = withoutBuild.indexOf("-");
+  if (dash === -1) return "stable";
+
+  const preRelease = withoutBuild.slice(dash + 1);
+  return preRelease.length > 0 ? "beta" : "stable";
+}
+
+export function isPreRelease(version: string): boolean {
+  return channelFor(version) === "beta";
+}
+
+/// Short label for the channel pill — "BETA" for anything pre-release.
+/// Returns null for stable so callers can skip rendering entirely.
+export function channelLabel(version: string): string | null {
+  return isPreRelease(version) ? "BETA" : null;
+}


### PR DESCRIPTION
A beta build was only distinguishable by squinting at the version in the settings footer — easy to forget which app you're testing, which defeats the point of the beta installing side by side.

## What it adds

`channelLabel()` in `utils/appChannel.ts`, driven by the **SemVer pre-release suffix** the beta workflow stamps into `tauri.conf.json` (`0.8.0-beta.7`). The version is the reliable signal — the workflow sets it directly, whereas `productName` could drift.

A `BETA` pill renders beside the Settings title in both the window and modal layouts, with the full version on hover (`Beta build — not the stable release — v0.8.0-beta.7`). Stable builds render nothing: `channelLabel` returns `null` rather than `""` so there's no stray node.

## Edge cases covered

- **Build metadata isn't a pre-release** — `0.8.0+abc1234` is stable, `0.8.0-beta.7+abc1234` is beta
- **Empty version maps to stable on purpose** — `getVersion()` is async and returns `""` on first render; flashing BETA on a stable build is worse than showing it a frame late
- `0.8.0-` (trailing dash, no identifier) is stable

8 unit tests cover these.

macOS-level naming already reads **Stik Beta** in the Dock, menu bar and About, since the workflow overrides `productName` — this covers the in-app surface.

Verified: 0 tsc errors, 108 tests pass, build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)