### PR TITLE
docs: give the exact path to the language picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Stable users never see these builds. Beta releases ship no updater artifacts and
 
 **On-device AI.** Semantic search, folder suggestions, and note embeddings through Apple's NaturalLanguage framework. No cloud, no API keys, nothing sent anywhere.
 
-**Language.** English and Simplified Chinese (简体中文). Switch under Settings, Appearance, and every open window follows without a restart.
+**Language.** English and Simplified Chinese (简体中文). Press `Cmd+Shift+,` and pick one from the first card in the Appearance tab. Every open window switches without a restart. Leave it on "Follow system language" and Stik reads your macOS setting.
 
 **Sync.** Turn on iCloud Drive in Settings and your notes reach your other Macs. Dropbox and Syncthing work too: point Stik at any folder they already watch.
 
@@ -187,7 +187,7 @@ npm test
 cd src-tauri && cargo test
 ```
 
-**Translations.** Every string lives in [`src/i18n/locales/`](src/i18n/locales/). Copy `en.ts`, translate the values, and add your locale to `LOCALES` in `src/i18n/index.ts`. The catalogue is typed against English, so a missing key breaks the build instead of shipping a blank label. Corrections to `zh-CN.ts` are welcome too.
+**Translations.** Every string lives in [`src/i18n/locales/`](src/i18n/locales/). Copy `en.ts`, translate the values, and add your locale to `LOCALES` in `src/i18n/index.ts`. The catalogue is typed against English, so a missing key breaks the build instead of shipping a blank label, and `npm test` checks both catalogues for drift. Corrections to [`zh-CN.ts`](src/i18n/locales/zh-CN.ts) are welcome: read it top to bottom without opening a single component.
 
 ## Ideas Board
 


### PR DESCRIPTION
Follow-up to #78. "Switch under Settings, Appearance" left you hunting for it.

Now names the shortcut (`Cmd+Shift+,`), says it's the **first card in the Appearance tab**, and explains what "Follow system language" actually does.

The translations note points straight at [`zh-CN.ts`](src/i18n/locales/zh-CN.ts) and mentions that `npm test` checks both catalogues for drift, since reviewing wording is the most likely contribution and needs no component knowledge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)