### PR TITLE
Phase 0: CI, atomic writes, and a watcher that ignores its own saves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,111 @@
+name: CI
+
+# Until now nothing ran the test suites: release.yml goes from `npm ci` straight
+# to notarization, and beta.yml does the same. Both only fire after the fact.
+on:
+  pull_request:
+  push:
+    branches: [main, develop]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          # jsdom is pinned to 29.x for this runner; see the note in package.json.
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Typecheck and build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+  rust:
+    name: Rust
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install protobuf compiler
+        # prost-build shells out to protoc.
+        run: brew install protobuf
+
+      - name: Stub the DarwinKit sidecar
+        # tauri-build only checks that the externalBin file exists. Nothing under
+        # test invokes it, so a no-op script keeps CI off the Swift build and the
+        # submodule checkout entirely.
+        run: |
+          target=$(rustc -vV | sed -n 's/^host: //p')
+          mkdir -p src-tauri/binaries
+          printf '#!/bin/sh\nexit 0\n' > "src-tauri/binaries/darwinkit-$target"
+          chmod +x "src-tauri/binaries/darwinkit-$target"
+
+      - name: Build the frontend
+        # tauri-build resolves frontendDist at compile time, so `cargo test`
+        # needs dist/ to exist.
+        run: |
+          npm ci
+          npm run build
+
+      - name: Test
+        run: cargo test --manifest-path src-tauri/Cargo.toml
+
+  lint:
+    name: Lint (advisory)
+    runs-on: macos-latest
+    # Formatting and clippy debt predates this workflow: 12 files fail
+    # `cargo fmt --check` and clippy reports ~12 warnings, three of them in files
+    # with in-flight work. Reporting the debt without blocking PRs on it. Flip
+    # continue-on-error off once `cargo fmt --all` and the clippy fixes land.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install protobuf compiler
+        run: brew install protobuf
+
+      - name: Stub the DarwinKit sidecar
+        run: |
+          target=$(rustc -vV | sed -n 's/^host: //p')
+          mkdir -p src-tauri/binaries
+          printf '#!/bin/sh\nexit 0\n' > "src-tauri/binaries/darwinkit-$target"
+          chmod +x "src-tauri/binaries/darwinkit-$target"
+
+      - name: Build the frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Formatting
+        run: cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings

--- a/src-tauri/src/commands/embeddings.rs
+++ b/src-tauri/src/commands/embeddings.rs
@@ -149,6 +149,12 @@ impl EmbeddingIndex {
     }
 
     /// Get the content hash for a path (to check if re-embedding is needed).
+    /// True if the stored embedding already matches this content. Lets callers
+    /// skip a sidecar round trip for a note that has not actually changed.
+    pub fn is_current(&self, path: &str, content: &str) -> bool {
+        self.get_hash(path).as_deref() == Some(content_hash(content).as_str())
+    }
+
     pub fn get_hash(&self, path: &str) -> Option<String> {
         let entries = self.entries.lock().unwrap_or_else(|e| e.into_inner());
         entries.get(path).map(|e| e.content_hash.clone())

--- a/src-tauri/src/commands/file_watcher.rs
+++ b/src-tauri/src/commands/file_watcher.rs
@@ -100,20 +100,48 @@ fn run(app: AppHandle, root: PathBuf) {
 /// Shared handler: update NoteIndex, EmbeddingIndex, emit frontend event.
 /// Used by both the local file watcher and iCloud notification handler.
 pub fn handle_changes(app: &AppHandle, paths: &[String]) {
-    let index = app.state::<NoteIndex>();
-    index.notify_external_change(paths);
+    // Our own saves already updated the index, so re-handling them would
+    // re-embed and re-broadcast every keystroke the app itself wrote.
+    let external: Vec<String> = paths
+        .iter()
+        .filter(|p| !storage::take_self_write(p))
+        .cloned()
+        .collect();
 
-    let emb = app.state::<EmbeddingIndex>();
-    for path_str in paths {
-        if let Ok(content) = storage::read_file(path_str) {
-            if !notes::is_effectively_empty_markdown(&content) {
-                if let Some(embedding) = embeddings::embed_content(&content) {
-                    emb.add_entry(path_str, embedding);
-                }
+    if external.is_empty() {
+        return;
+    }
+
+    let index = app.state::<NoteIndex>();
+    index.notify_external_change(&external);
+
+    // Embedding costs two blocking sidecar round trips per note, so it is gated
+    // on the AI setting (as the save path is) and skipped when the content hash
+    // already matches. Without both, landing a large batch of files — an import,
+    // an iCloud download, a restore — serialises thousands of RPCs here.
+    if super::settings::load_settings_from_file()
+        .map(|s| s.ai_features_enabled)
+        .unwrap_or(false)
+    {
+        let emb = app.state::<EmbeddingIndex>();
+        let mut embedded = 0;
+        for path_str in &external {
+            let Ok(content) = storage::read_file(path_str) else {
+                continue;
+            };
+            if notes::is_effectively_empty_markdown(&content) || emb.is_current(path_str, &content)
+            {
+                continue;
+            }
+            if let Some(embedding) = embeddings::embed_content(&content) {
+                emb.add_entry(path_str, embedding);
+                embedded += 1;
             }
         }
+        if embedded > 0 {
+            let _ = emb.save();
+        }
     }
-    let _ = emb.save();
 
-    let _ = app.emit("files-changed", paths);
+    let _ = app.emit("files-changed", &external);
 }

--- a/src-tauri/src/commands/note_lock.rs
+++ b/src-tauri/src/commands/note_lock.rs
@@ -254,6 +254,7 @@ pub fn lock_session() -> Result<(), String> {
 pub fn lock_note(
     path: String,
     index: tauri::State<'_, super::index::NoteIndex>,
+    embeddings: tauri::State<'_, super::embeddings::EmbeddingIndex>,
 ) -> Result<(), String> {
     let content = storage::read_file(&path)?;
 
@@ -269,6 +270,12 @@ pub fn lock_note(
 
     // Re-index so the UI sees the updated locked state
     index.add(&path, &folder);
+
+    // The embedding is derived from plaintext, so keeping it would leave a
+    // readable shadow of a locked note in ~/.stik/embeddings.json. build_embeddings
+    // already skips locked notes; this closes the same hole on the way in.
+    embeddings.remove_entry(&path);
+    let _ = embeddings.save();
 
     Ok(())
 }

--- a/src-tauri/src/commands/storage.rs
+++ b/src-tauri/src/commands/storage.rs
@@ -4,8 +4,11 @@
 /// When iCloud is enabled, all file operations go through NSFileCoordinator
 /// via DarwinKit JSON-RPC. When local or custom, direct std::fs (current behavior).
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use super::darwinkit;
 use super::settings;
@@ -109,6 +112,63 @@ fn icloud_stik_root() -> Result<PathBuf, String> {
     Ok(path)
 }
 
+// ── Atomic Writes ─────────────────────────────────────────────────
+//
+// A truncating `fs::write` leaves a window where a reader sees a half-written
+// note. Finder, Obsidian, the file watcher and any future sync agent all read
+// this tree, so notes go out temp-file-then-rename — the same shape the JSON
+// stores already use.
+
+fn atomic_write(path: &str, data: &[u8]) -> Result<(), String> {
+    let target = Path::new(path);
+    let dir = target
+        .parent()
+        .ok_or_else(|| format!("{} has no parent directory", path))?;
+    let name = target
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| format!("{} has no filename", path))?;
+
+    // Leading dot and a .tmp extension keep the partial file out of both the
+    // note index (skips dot-entries) and the watcher (matches .md only).
+    let tmp = dir.join(format!(".{}.tmp", name));
+
+    fs::write(&tmp, data).map_err(|e| format!("Failed to write {}: {}", tmp.display(), e))?;
+    fs::rename(&tmp, target).map_err(|e| {
+        let _ = fs::remove_file(&tmp);
+        format!("Failed to replace {}: {}", path, e)
+    })
+}
+
+// ── Self-Write Suppression ────────────────────────────────────────
+//
+// The watcher cannot tell our own writes from someone editing the file in
+// another app, so it re-reads, re-embeds and re-broadcasts every save we make.
+// Each write records its path here and the watcher drops the matching event.
+
+const SELF_WRITE_WINDOW: Duration = Duration::from_secs(2);
+
+fn recent_writes() -> &'static Mutex<HashMap<String, Instant>> {
+    static RECENT: OnceLock<Mutex<HashMap<String, Instant>>> = OnceLock::new();
+    RECENT.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn record_self_write(path: &str) {
+    let mut map = recent_writes().lock().unwrap_or_else(|e| e.into_inner());
+    map.retain(|_, at| at.elapsed() < SELF_WRITE_WINDOW);
+    map.insert(path.to_string(), Instant::now());
+}
+
+/// True if this app wrote `path` within the suppression window. Consumes the
+/// record, so a real external edit straight after ours is still seen.
+pub fn take_self_write(path: &str) -> bool {
+    let mut map = recent_writes().lock().unwrap_or_else(|e| e.into_inner());
+    match map.remove(path) {
+        Some(at) => at.elapsed() < SELF_WRITE_WINDOW,
+        None => false,
+    }
+}
+
 // ── File Operations ───────────────────────────────────────────────
 
 pub fn read_file(path: &str) -> Result<String, String> {
@@ -130,6 +190,7 @@ pub fn read_file(path: &str) -> Result<String, String> {
 }
 
 pub fn write_file(path: &str, content: &str) -> Result<(), String> {
+    record_self_write(path);
     match current_mode() {
         StorageMode::ICloud => {
             darwinkit::call_with_timeout(
@@ -139,7 +200,7 @@ pub fn write_file(path: &str, content: &str) -> Result<(), String> {
             )?;
             Ok(())
         }
-        _ => fs::write(path, content).map_err(|e| e.to_string()),
+        _ => atomic_write(path, content.as_bytes()),
     }
 }
 
@@ -155,7 +216,7 @@ pub fn write_bytes(path: &str, data: &[u8]) -> Result<(), String> {
             )?;
             Ok(())
         }
-        _ => fs::write(path, data).map_err(|e| e.to_string()),
+        _ => atomic_write(path, data),
     }
 }
 
@@ -333,4 +394,119 @@ pub fn start_monitoring() -> Result<(), String> {
 pub fn stop_monitoring() -> Result<(), String> {
     darwinkit::call("icloud.stop_monitoring", None)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_dir(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be monotonic")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("stik-storage-{label}-{nanos}"));
+        fs::create_dir_all(&dir).expect("temp dir should be creatable");
+        dir
+    }
+
+    #[test]
+    fn atomic_write_creates_the_file_and_leaves_no_temp_behind() {
+        let dir = unique_temp_dir("create");
+        let note = dir.join("20260730-120000-hello-ab12.md");
+
+        atomic_write(note.to_str().unwrap(), b"# hello").expect("write should succeed");
+
+        assert_eq!(fs::read_to_string(&note).unwrap(), "# hello");
+        let leftovers: Vec<_> = fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .filter(|name| name.ends_with(".tmp"))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "temp files left behind: {leftovers:?}"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn atomic_write_replaces_existing_content_wholesale() {
+        let dir = unique_temp_dir("replace");
+        let note = dir.join("note.md");
+        fs::write(&note, "a much longer previous body").unwrap();
+
+        atomic_write(note.to_str().unwrap(), b"short").expect("write should succeed");
+
+        // A truncating write that failed midway would leave the tail of the old
+        // body; rename cannot.
+        assert_eq!(fs::read_to_string(&note).unwrap(), "short");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// The property that matters: a concurrent reader never sees a partial note.
+    /// A truncating `fs::write` fails this — the reader catches the window
+    /// between truncate and the bytes landing, and reads a short or empty file.
+    #[test]
+    fn a_concurrent_reader_never_sees_a_partial_note() {
+        let dir = unique_temp_dir("concurrent");
+        let note = dir.join("note.md");
+        let long = "x".repeat(64 * 1024);
+        let short = "y".repeat(512);
+        fs::write(&note, &long).unwrap();
+
+        let reader_path = note.clone();
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let reader_stop = stop.clone();
+
+        let reader = std::thread::spawn(move || {
+            let mut partials = 0;
+            while !reader_stop.load(std::sync::atomic::Ordering::Relaxed) {
+                if let Ok(seen) = fs::read_to_string(&reader_path) {
+                    if seen.len() != 64 * 1024 && seen.len() != 512 {
+                        partials += 1;
+                    }
+                }
+            }
+            partials
+        });
+
+        let path_str = note.to_str().unwrap();
+        for i in 0..200 {
+            let body = if i % 2 == 0 { &short } else { &long };
+            atomic_write(path_str, body.as_bytes()).expect("write should succeed");
+        }
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let partials = reader.join().expect("reader thread should not panic");
+        assert_eq!(partials, 0, "reader saw {partials} partially-written notes");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn atomic_write_rejects_a_path_with_no_filename() {
+        assert!(atomic_write("/", b"x").is_err());
+    }
+
+    #[test]
+    fn self_write_is_seen_once_then_forgotten() {
+        let path = "/tmp/stik-self-write-once.md";
+        record_self_write(path);
+
+        assert!(take_self_write(path), "our own write should be suppressed");
+        assert!(
+            !take_self_write(path),
+            "a second event on the same path is an external edit"
+        );
+    }
+
+    #[test]
+    fn a_path_we_never_wrote_is_never_suppressed() {
+        assert!(!take_self_write("/tmp/stik-never-written.md"));
+    }
 }


### PR DESCRIPTION
The mobile plan's Phase 0 items that live outside `folders.rs` / `index.rs` / `notes.rs`, kept clear of the in-flight nested-folder work.

## CI, finally

Nothing ran a test before this. `release.yml` and `beta.yml` both go from `npm ci` straight to notarization, and only after a tag. `ROADMAP.md` has called PR CI the highest-value fix in the repo since 0.9 planning.

- **frontend** — typecheck, build, vitest (112 tests)
- **rust** — `cargo test` on macOS (61 tests)
- **lint** — `fmt --check` and `clippy -D warnings`, advisory for now

The sidecar is stubbed with a no-op script: `tauri-build` only checks the `externalBin` path exists and nothing under test invokes it, so CI skips the Swift build and the submodule entirely.

Lint is `continue-on-error: true` deliberately. 12 files fail `fmt --check` today and clippy reports ~12 warnings, three in files with uncommitted work — blocking on that would block every PR. One `cargo fmt --all` pass later, flip it.

## Three sync hazards in the notes tree

**Atomic writes.** `storage::write_file` used a truncating `fs::write`, so a reader — Finder, Obsidian, the watcher, a future sync agent — could catch a half-written note and take it as the newest revision. Now temp-file-plus-rename, matching what `cursor_positions.rs` and `embeddings.rs` already do.

The test spawns a reader thread against 200 alternating long/short writes and asserts it never sees a partial. It fails with `fs::write` and passes with rename — verified both ways.

**Self-write suppression.** The watcher could not distinguish our own saves from external edits, so every save was re-read, re-embedded, and re-broadcast. Writes now record their path; the watcher drops the matching event and consumes the record, so a genuine external edit right after ours is still seen.

**Embedding is gated and hash-skipped.** `handle_changes` re-embedded every changed file with two blocking sidecar RPCs each, ungated by `ai_features_enabled` even though the save path checks it, and with no content-hash skip. Landing a batch serialised thousands of RPCs on the watcher thread. This is what would have made the Phase 4 restore drill fail on the client rather than the network.

## One leak

`lock_note` left the note's plaintext-derived embedding in `~/.stik/embeddings.json` indefinitely. `build_embeddings` already skips locked notes, so this was the same hole on the way in.

## Not in here

The blocking Phase 0 item — a stable per-note ID — needs a product decision first (frontmatter vs sidecar) and touches the three files with in-flight work. Same for `rename_folder` repairing both indices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)