### PR TITLE
feat(editor): VoiceOver announcements for deletions and newlines

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -17,7 +17,6 @@ import {
   EditorView,
   drawSelection,
   keymap,
-  placeholder as cmPlaceholder,
 } from "@codemirror/view";
 import { defaultKeymap, history, historyKeymap, indentWithTab, insertNewline } from "@codemirror/commands";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
@@ -56,6 +55,7 @@ import { highlightExtension } from "@/extensions/cm-highlight";
 import { taskCheckboxPlugin, taskCheckboxHandler } from "@/extensions/cm-task-toggle";
 import { hideMarkersPlugin, autoCloseMarkup } from "@/extensions/cm-hide-markers";
 import { headingFoldPlugin } from "@/extensions/cm-heading-fold";
+import { accessibleEditor } from "@/extensions/cm-a11y";
 import { filenameToSlug } from "@/utils/wikiLink";
 import { normalizeUrl } from "@/utils/normalizeUrl";
 import { isImageUrl } from "@/utils/isImageUrl";
@@ -219,6 +219,7 @@ const Editor = forwardRef<EditorRef, EditorProps>(
                   view.dispatch({
                     changes: { from: head + 2, insert: "\n" },
                     selection: { anchor: head + 2 + 1 },
+                    userEvent: "input",
                   });
                   return true;
                 }
@@ -526,7 +527,7 @@ const Editor = forwardRef<EditorRef, EditorProps>(
         // @replit/codemirror-vim makes native ::selection transparent.
         // drawSelection renders .cm-selectionBackground instead.
         drawSelection(),
-        placeholderCompartment.of(cmPlaceholder(placeholderText)),
+        placeholderCompartment.of(accessibleEditor(placeholderText)),
         search(),
         richCopyHandler,
         imageHandlers,
@@ -602,7 +603,7 @@ const Editor = forwardRef<EditorRef, EditorProps>(
       if (!view) return;
       view.dispatch({
         effects: placeholderCompartment.reconfigure(
-          cmPlaceholder(placeholderText),
+          accessibleEditor(placeholderText),
         ),
       });
     }, [placeholderText]);

--- a/src/extensions/cm-a11y.dom.test.ts
+++ b/src/extensions/cm-a11y.dom.test.ts
@@ -1,0 +1,97 @@
+/**
+ * DOM-level verification that the accessibility wiring produces the right
+ * accessible tree — not just the right strings. If the announcement text lands
+ * in CodeMirror's aria-live region, a screen reader will speak it.
+ */
+import { describe, it, expect } from "vitest";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { accessibleEditor } from "./cm-a11y";
+
+function mount(doc: string, anchor = doc.length) {
+  const parent = document.createElement("div");
+  document.body.appendChild(parent);
+  const view = new EditorView({
+    state: EditorState.create({
+      doc,
+      selection: { anchor },
+      extensions: [accessibleEditor("Type a thought...")],
+    }),
+    parent,
+  });
+  return {
+    view,
+    cleanup: () => {
+      view.destroy();
+      parent.remove();
+    },
+  };
+}
+
+const announced = (view: EditorView): string =>
+  view.dom.querySelector(".cm-announced")?.textContent ?? "";
+
+describe("accessibleEditor — accessible DOM", () => {
+  it("gives the editor a stable aria-label and NO repeating aria-placeholder", () => {
+    const { view, cleanup } = mount("");
+    try {
+      expect(view.contentDOM.getAttribute("aria-label")).toBe(
+        "Type a thought...",
+      );
+      // Passing an element (not a string) means CM6 omits aria-placeholder —
+      // this is what stops VoiceOver re-reading the hint on every pause.
+      expect(view.contentDOM.getAttribute("aria-placeholder")).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("renders the placeholder hidden from assistive tech (aria-hidden)", () => {
+    const { view, cleanup } = mount(""); // empty doc → placeholder shows
+    try {
+      const ph = view.dom.querySelector(".cm-placeholder");
+      expect(ph).not.toBeNull();
+      expect(ph?.getAttribute("aria-hidden")).toBe("true");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("announces a deleted character into the aria-live region", () => {
+    const { view, cleanup } = mount("abc", 3);
+    try {
+      view.dispatch({
+        changes: { from: 2, to: 3 },
+        selection: { anchor: 2 },
+        userEvent: "delete.backward",
+      });
+      expect(announced(view)).toContain("deleted c");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("announces a newline into the aria-live region", () => {
+    const { view, cleanup } = mount("ab", 2);
+    try {
+      view.dispatch({
+        changes: { from: 2, insert: "\n" },
+        selection: { anchor: 3 },
+        userEvent: "input",
+      });
+      expect(announced(view)).toContain("new line");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("uses a polite live region so it won't interrupt typing", () => {
+    const { view, cleanup } = mount("abc", 3);
+    try {
+      const region = view.dom.querySelector(".cm-announced");
+      expect(region?.getAttribute("aria-live")).toBe("polite");
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/extensions/cm-a11y.test.ts
+++ b/src/extensions/cm-a11y.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { EditorState, type TransactionSpec } from "@codemirror/state";
+import { describeEdit } from "./cm-a11y";
+
+/** Build a transaction from a starting doc/selection so describeEdit can read it. */
+function makeTr(
+  doc: string,
+  spec: TransactionSpec,
+  selection?: { anchor: number; head: number },
+) {
+  return EditorState.create({ doc, selection }).update(spec);
+}
+
+describe("describeEdit", () => {
+  it("announces a single deleted character", () => {
+    const tr = makeTr("abc", {
+      changes: { from: 2, to: 3 },
+      userEvent: "delete.backward",
+    });
+    expect(describeEdit(tr)).toBe("deleted c");
+  });
+
+  it("announces a deleted word (Option-Backspace)", () => {
+    const tr = makeTr("hello world", {
+      changes: { from: 6, to: 11 },
+      userEvent: "delete.backward",
+    });
+    expect(describeEdit(tr)).toBe("deleted world");
+  });
+
+  it("names a deleted space", () => {
+    const tr = makeTr("a b", {
+      changes: { from: 1, to: 2 },
+      userEvent: "delete.backward",
+    });
+    expect(describeEdit(tr)).toBe("deleted space");
+  });
+
+  it("announces deleting a line break", () => {
+    const tr = makeTr("a\nb", {
+      changes: { from: 1, to: 2 },
+      userEvent: "delete.backward",
+    });
+    expect(describeEdit(tr)).toBe("deleted new line");
+  });
+
+  it("announces a newline insertion (Enter)", () => {
+    const tr = makeTr("ab", {
+      changes: { from: 2, insert: "\n" },
+      userEvent: "input",
+    });
+    expect(describeEdit(tr)).toBe("new line");
+  });
+
+  it("stays silent for typed characters", () => {
+    const tr = makeTr("ab", {
+      changes: { from: 2, insert: "c" },
+      userEvent: "input",
+    });
+    expect(describeEdit(tr)).toBeNull();
+  });
+
+  it("stays silent for selection deletions (commands announces those)", () => {
+    const tr = makeTr(
+      "abc",
+      { changes: { from: 0, to: 2 }, userEvent: "delete.backward" },
+      { anchor: 0, head: 2 },
+    );
+    expect(describeEdit(tr)).toBeNull();
+  });
+
+  it("stays silent for non-document transactions", () => {
+    const tr = makeTr("abc", { selection: { anchor: 1 } });
+    expect(describeEdit(tr)).toBeNull();
+  });
+});

--- a/src/extensions/cm-a11y.ts
+++ b/src/extensions/cm-a11y.ts
@@ -1,0 +1,80 @@
+/**
+ * Screen-reader announcements for the editor (VoiceOver / NVDA).
+ *
+ * CodeMirror applies Backspace/Delete/Enter through its own transactions, so the
+ * browser never fires the native input events screen readers use to speak deleted
+ * characters or "new line". We read the change out of the transaction and push a
+ * short message into CM6's built-in aria-live region (EditorView.announce), which
+ * is invisible and silent for sighted users.
+ *
+ * Selection deletions are already announced by @codemirror/commands, so we only
+ * speak caret-level deletions and newline insertions to avoid double announcements.
+ */
+import {
+  EditorState,
+  type Extension,
+  type Transaction,
+} from "@codemirror/state";
+import { EditorView, placeholder as cmPlaceholder } from "@codemirror/view";
+
+/** Turn a deleted/inserted run into something a screen reader can speak aloud. */
+function speak(text: string): string {
+  if (text === "\n") return "new line";
+  if (text === " ") return "space";
+  if (text === "\t") return "tab";
+  return text.replace(/\n/g, " new line ").trim() || "blank";
+}
+
+/**
+ * The message to announce for a transaction, or null to stay silent.
+ * Exported for unit testing — pure, needs no DOM or EditorView.
+ */
+export function describeEdit(tr: Transaction): string | null {
+  if (!tr.docChanged) return null;
+
+  // Caret deletion. Non-empty selections (including cut) are already announced
+  // by @codemirror/commands, so skip them to avoid speaking the same edit twice.
+  if (tr.isUserEvent("delete")) {
+    if (!tr.startState.selection.main.empty) return null;
+    let removed = "";
+    tr.changes.iterChanges((fromA, toA) => {
+      if (toA > fromA) removed += tr.startState.doc.sliceString(fromA, toA);
+    });
+    return removed ? `deleted ${speak(removed)}` : null;
+  }
+
+  // Newline insertion (Enter).
+  if (tr.isUserEvent("input")) {
+    let inserted = "";
+    tr.changes.iterChanges((_fromA, _toA, _fromB, _toB, ins) => {
+      inserted += ins.toString();
+    });
+    if (inserted === "\n") return "new line";
+  }
+
+  return null;
+}
+
+/** Appends an aria-live announcement to delete/newline transactions. */
+const announceEdits = EditorState.transactionExtender.of((tr) => {
+  const message = describeEdit(tr);
+  return message ? { effects: EditorView.announce.of(message) } : null;
+});
+
+/**
+ * Accessible placeholder + edit announcements for the editor.
+ *
+ * The placeholder is handed to CM6 as an element rather than a string: that makes
+ * CM6 mark it aria-hidden AND skip the aria-placeholder attribute, so VoiceOver no
+ * longer re-reads it on every pause. The field instead gets a stable accessible
+ * name via aria-label, announced once when focus enters.
+ */
+export function accessibleEditor(placeholderText: string): Extension {
+  const placeholderEl = document.createElement("span");
+  placeholderEl.textContent = placeholderText;
+  return [
+    cmPlaceholder(placeholderEl),
+    EditorView.contentAttributes.of({ "aria-label": placeholderText }),
+    announceEdits,
+  ];
+}


### PR DESCRIPTION
Rescued from a commit that existed only on a local `main` which had fallen 4 commits behind `origin/main`. It would have been lost on the next reset.

CodeMirror applies Backspace/Delete/Enter through its own transactions, so the browser never fires the native input events screen readers listen for — VoiceOver stays silent on deletions and newlines. A `transactionExtender` reads the change out of the transaction and pushes a short message into CM6's built-in aria-live region. Selection deletions are skipped, since `@codemirror/commands` already announces those and we would otherwise speak each edit twice.

The placeholder is now handed to CM6 as an element rather than a string. That makes CM6 mark it `aria-hidden` and skip `aria-placeholder`, so VoiceOver stops re-reading the placeholder on every pause; the field gets a stable accessible name via `aria-label` instead.

## Conflict resolution worth reviewing

This commit predates the placeholder-locale fix and collided with it. Rather than picking a side, `accessibleEditor` now goes *inside* the existing `Compartment`:

```ts
placeholderCompartment.of(accessibleEditor(placeholderText)),
```

So switching language reconfigures the compartment and updates the `aria-label` too, not just the visible placeholder text. Both behaviours survive, and the accessible name follows the locale.

`describeEdit` is exported as a pure function so most of the logic is testable without a DOM.

125 frontend tests pass, up from 112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)