### PR TITLE
chore: dependabot config and the ConfirmDialog test

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+version: 2
+
+# Without this file GitHub only opens *security* PRs, so routine versions drift
+# until an advisory forces a large jump. Everything here is grouped so a week's
+# updates arrive as one reviewable PR per ecosystem rather than a dozen.
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      react:
+        patterns: ["react", "react-dom", "@types/react", "@types/react-dom"]
+      codemirror:
+        patterns: ["@codemirror/*", "codemirror", "@replit/codemirror-vim"]
+      tauri:
+        # The Tauri npm packages must stay on the same major/minor as the Rust
+        # `tauri` crate or tauri-cli refuses to build, so they move together.
+        patterns: ["@tauri-apps/*"]
+      dev-dependencies:
+        dependency-type: development
+        exclude-patterns: ["@tauri-apps/*"]
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+
+  - package-ecosystem: cargo
+    directory: "/src-tauri"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      tauri:
+        patterns: ["tauri", "tauri-*"]
+      cargo-minor-patch:
+        update-types: ["minor", "patch"]
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "chore(ci)"

--- a/src/components/ConfirmDialog.test.tsx
+++ b/src/components/ConfirmDialog.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ConfirmDialog from "./ConfirmDialog";
+import { setLocale } from "@/i18n";
+
+afterEach(() => {
+  setLocale("en");
+});
+
+describe("ConfirmDialog", () => {
+  it("renders the title", () => {
+    render(
+      <ConfirmDialog
+        title="Delete theme?"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    expect(screen.getByText("Delete theme?")).toBeInTheDocument();
+  });
+
+  it("renders the description only when provided", () => {
+    const { rerender } = render(
+      <ConfirmDialog title="T" onConfirm={() => {}} onCancel={() => {}} />,
+    );
+    expect(screen.queryByText("This cannot be undone")).not.toBeInTheDocument();
+
+    rerender(
+      <ConfirmDialog
+        title="T"
+        description="This cannot be undone"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    expect(screen.getByText("This cannot be undone")).toBeInTheDocument();
+  });
+
+  it("defaults the confirm button to the translated Delete label", () => {
+    render(
+      <ConfirmDialog title="T" onConfirm={() => {}} onCancel={() => {}} />,
+    );
+    expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+  });
+
+  it("uses an explicit confirmLabel when given", () => {
+    render(
+      <ConfirmDialog
+        title="T"
+        confirmLabel="Remove font"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Remove font" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Delete" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("fires onConfirm when the confirm button is clicked", () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog title="T" onConfirm={onConfirm} onCancel={() => {}} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onCancel when the cancel button is clicked", () => {
+    const onCancel = vi.fn();
+    render(
+      <ConfirmDialog title="T" onConfirm={() => {}} onCancel={onCancel} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels on Escape", () => {
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog title="T" onConfirm={onConfirm} onCancel={onCancel} />,
+    );
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("confirms on Enter", () => {
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog title="T" onConfirm={onConfirm} onCancel={onCancel} />,
+    );
+
+    fireEvent.keyDown(window, { key: "Enter" });
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("ignores unrelated keys", () => {
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog title="T" onConfirm={onConfirm} onCancel={onCancel} />,
+    );
+
+    fireEvent.keyDown(window, { key: "a" });
+    fireEvent.keyDown(window, { key: "Tab" });
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("stops listening for keys once unmounted", () => {
+    // The listener is registered on `window` in capture phase; leaking it
+    // would let a dismissed dialog keep swallowing Escape for the whole app.
+    const onCancel = vi.fn();
+    const { unmount } = render(
+      <ConfirmDialog title="T" onConfirm={() => {}} onCancel={onCancel} />,
+    );
+
+    unmount();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("renders its chrome in the active locale", () => {
+    setLocale("zh-CN");
+    render(
+      <ConfirmDialog title="T" onConfirm={() => {}} onCancel={() => {}} />,
+    );
+
+    expect(screen.getByRole("button", { name: "取消" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "删除" })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Both files were sitting **uncommitted** in a `v0.9-hardening` worktree and would have been destroyed by the branch cleanup. Salvaged first.

`.github/dependabot.yml` closes the second blocking v0.9 item from the roadmap. Without the file GitHub opens security PRs only, so routine versions drift until an advisory forces a large jump. Updates are grouped so a week lands as one reviewable PR per ecosystem instead of a dozen.

The `@tauri-apps/*` group is deliberate: the npm packages have to stay on the same major/minor as the Rust `tauri` crate or `tauri-cli` refuses to build, so they move together.

`ConfirmDialog` had no test. This covers the title, both callbacks, the destructive variant, and locale switching — 11 assertions, passing against develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)