### PR TITLE
fix(fonts): no font has ever loaded — the CSP blocked all of them

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,8 +1,9 @@
 use super::{git_share, versioning};
+use base64::Engine;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ShortcutMapping {
@@ -582,5 +583,160 @@ mod tests {
         assert_eq!(parse_color_value("#112233"), Some("17 34 51".to_string()));
         assert_eq!(parse_color_value("10 20 30"), Some("10 20 30".to_string()));
         assert_eq!(parse_color_value("not-a-color"), None);
+    }
+}
+
+// ── Custom Fonts ─────────────────────────────────────────────────
+//
+// Imported fonts are copied into ~/.stik/fonts rather than referenced where the
+// user found them. A path under Downloads breaks as soon as the file moves, and
+// the asset protocol's scope does not reach outside the notes folder anyway.
+// The bytes go back to the webview as a data: URL, which avoids the asset
+// protocol and its per-platform URL scheme entirely.
+
+const FONT_EXTENSIONS: [&str; 4] = ["ttf", "otf", "woff", "woff2"];
+
+fn font_mime(ext: &str) -> &'static str {
+    match ext {
+        "otf" => "font/otf",
+        "woff" => "font/woff",
+        "woff2" => "font/woff2",
+        _ => "font/ttf",
+    }
+}
+
+fn fonts_dir() -> Result<PathBuf, String> {
+    let home = dirs::home_dir().ok_or("Cannot determine home directory")?;
+    let dir = home.join(".stik").join("fonts");
+    fs::create_dir_all(&dir).map_err(|e| format!("Failed to create fonts directory: {}", e))?;
+    Ok(dir)
+}
+
+/// Derive the CSS family name from a font file's basename.
+/// Mirrors the previous frontend behaviour so names do not change.
+pub fn font_family_name(file_name: &str) -> String {
+    let stem = file_name
+        .rsplit_once('.')
+        .map(|(s, _)| s)
+        .unwrap_or(file_name);
+    stem.replace(['-', '_'], " ")
+}
+
+fn font_extension(path: &Path) -> Result<String, String> {
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())
+        .ok_or("Font file has no extension")?;
+    if !FONT_EXTENSIONS.contains(&ext.as_str()) {
+        return Err(format!(
+            "Unsupported font format '.{}'. Use .ttf, .otf, .woff or .woff2",
+            ext
+        ));
+    }
+    Ok(ext)
+}
+
+#[tauri::command]
+pub fn import_font_file(path: String) -> Result<CustomFontEntry, String> {
+    let source = Path::new(&path);
+    font_extension(source)?;
+
+    let file_name = source
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or("Font file has no name")?;
+
+    let destination = fonts_dir()?.join(file_name);
+    if source != destination {
+        fs::copy(source, &destination)
+            .map_err(|e| format!("Failed to copy font into ~/.stik/fonts: {}", e))?;
+    }
+
+    Ok(CustomFontEntry {
+        name: font_family_name(file_name),
+        path: destination.to_string_lossy().to_string(),
+    })
+}
+
+/// Read an imported font and return it as a `data:` URL for the FontFace API.
+#[tauri::command]
+pub fn load_font_data(path: String) -> Result<String, String> {
+    let file = Path::new(&path);
+    let ext = font_extension(file)?;
+
+    // This hands raw file bytes to the webview, so it must never read outside
+    // the fonts directory — canonicalize both sides so `..` cannot escape.
+    let canonical = file
+        .canonicalize()
+        .map_err(|e| format!("Font file not found: {}", e))?;
+    let dir = fonts_dir()?
+        .canonicalize()
+        .map_err(|e| format!("Fonts directory unavailable: {}", e))?;
+    if !canonical.starts_with(&dir) {
+        return Err("Fonts can only be loaded from ~/.stik/fonts".to_string());
+    }
+
+    let bytes = fs::read(&canonical).map_err(|e| format!("Failed to read font: {}", e))?;
+    let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+    Ok(format!("data:{};base64,{}", font_mime(&ext), encoded))
+}
+
+#[cfg(test)]
+mod font_tests {
+    use super::*;
+
+    #[test]
+    fn family_name_strips_extension_and_separators() {
+        assert_eq!(
+            font_family_name("JetBrains-Mono_Regular.ttf"),
+            "JetBrains Mono Regular"
+        );
+        assert_eq!(font_family_name("Inter.woff2"), "Inter");
+    }
+
+    #[test]
+    fn family_name_survives_a_name_with_no_extension() {
+        assert_eq!(font_family_name("PlainName"), "PlainName");
+    }
+
+    #[test]
+    fn font_extension_accepts_every_supported_format() {
+        for ext in FONT_EXTENSIONS {
+            let name = format!("Some-Font.{}", ext);
+            assert_eq!(font_extension(Path::new(&name)).unwrap(), ext);
+        }
+    }
+
+    #[test]
+    fn font_extension_is_case_insensitive() {
+        assert_eq!(font_extension(Path::new("Some.TTF")).unwrap(), "ttf");
+    }
+
+    #[test]
+    fn font_extension_rejects_a_non_font() {
+        // The picker filters, but the path also arrives from settings.json.
+        assert!(font_extension(Path::new("secrets.env")).is_err());
+        assert!(font_extension(Path::new("noextension")).is_err());
+    }
+
+    #[test]
+    fn load_font_data_refuses_paths_outside_the_fonts_directory() {
+        // Guards the arbitrary-read primitive: a font extension alone is not
+        // enough, the file has to live in ~/.stik/fonts.
+        // No extension at all.
+        let err = load_font_data("/etc/passwd".to_string()).unwrap_err();
+        assert!(err.contains("no extension"), "got: {err}");
+
+        // A real extension, but not a font one.
+        let err = load_font_data("/etc/hosts.env".to_string()).unwrap_err();
+        assert!(err.contains("Unsupported font format"), "got: {err}");
+
+        // Font extension, but outside ~/.stik/fonts — the case that matters.
+        let outside = std::env::temp_dir().join("stik-outside-fonts-dir.ttf");
+        fs::write(&outside, b"not really a font").unwrap();
+        let err = load_font_data(outside.to_string_lossy().to_string()).unwrap_err();
+        assert!(err.contains("~/.stik/fonts"), "got: {err}");
+        let _ = fs::remove_file(&outside);
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -493,6 +493,8 @@ fn main() {
             settings::save_viewing_window_geometry,
             settings::save_capture_window_size,
             settings::import_theme_file,
+            settings::import_font_file,
+            settings::load_font_data,
             settings::export_theme_file,
             darwinkit::darwinkit_status,
             darwinkit::darwinkit_call,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -32,7 +32,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; img-src 'self' data: http://asset.localhost https://asset.localhost https: http:; connect-src ipc: http://ipc.localhost",
+      "csp": "default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self'; img-src 'self' data: http://asset.localhost https://asset.localhost https: http:; font-src 'self' data: https://fonts.gstatic.com; connect-src ipc: http://ipc.localhost",
       "assetProtocol": {
         "enable": true,
         "scope": [

--- a/src/components/SettingsContent.tsx
+++ b/src/components/SettingsContent.tsx
@@ -31,7 +31,6 @@ import {
   FONTS,
   loadGoogleFont,
   loadCustomFont,
-  fontNameFromPath,
 } from "@/utils/fonts";
 
 function remoteToWebUrl(remoteUrl: string): string | null {
@@ -848,20 +847,29 @@ function AppearanceSection({
     });
     if (!selected) return;
 
-    const name = fontNameFromPath(selected);
-    // Avoid duplicates (same path)
-    if (customFonts.some((f) => f.path === selected)) {
+    // Copy into ~/.stik/fonts first: the picked file may sit anywhere, and a
+    // font referenced in place stops working the moment the user moves it.
+    let entry: CustomFontEntry;
+    try {
+      entry = await invoke<CustomFontEntry>("import_font_file", { path: selected });
+    } catch (error) {
+      setToast(typeof error === "string" ? error : t("settings.font.loadFailed"));
+      return;
+    }
+
+    const { name } = entry;
+    if (customFonts.some((f) => f.path === entry.path)) {
       setToast(`Font "${name}" is already imported`);
       return;
     }
 
-    const ok = await loadCustomFont(name, selected);
+    const ok = await loadCustomFont(name, entry.path);
     if (!ok) {
       setToast(t("settings.font.loadFailed"));
       return;
     }
 
-    const updated = [...customFonts, { name, path: selected }];
+    const updated = [...customFonts, entry];
     onSettingsChange({ ...settings, custom_fonts: updated });
     setToast(`Font "${name}" imported`);
   };

--- a/src/utils/csp.test.ts
+++ b/src/utils/csp.test.ts
@@ -1,0 +1,49 @@
+/**
+ * The CSP has to permit the sources the font code actually loads from.
+ *
+ * This existed as a silent, total failure: there was no `font-src` at all, so it
+ * fell back to `default-src 'self'` and every font — the bundled Google ones and
+ * any user-imported file — was blocked with nothing but a console violation.
+ * Parsing the real config keeps the two in sync.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const config = JSON.parse(
+  readFileSync(resolve(__dirname, "../../src-tauri/tauri.conf.json"), "utf-8"),
+) as { app: { security: { csp: string } } };
+
+function directive(name: string): string[] | null {
+  for (const part of config.app.security.csp.split(";")) {
+    const tokens = part.trim().split(/\s+/);
+    if (tokens[0] === name) return tokens.slice(1);
+  }
+  return null;
+}
+
+describe("CSP font sources", () => {
+  it("declares font-src explicitly rather than inheriting default-src", () => {
+    // Without this, default-src 'self' silently blocks every font.
+    expect(directive("font-src")).not.toBeNull();
+  });
+
+  it("allows data: URLs, which is how imported font files are loaded", () => {
+    expect(directive("font-src")).toContain("data:");
+  });
+
+  it("allows the Google Fonts file origin for the built-in families", () => {
+    expect(directive("font-src")).toContain("https://fonts.gstatic.com");
+  });
+
+  it("allows the Google Fonts stylesheet origin", () => {
+    // loadGoogleFont() injects <link rel=stylesheet> pointing here, so
+    // style-src has to permit it or the built-in fonts never resolve.
+    expect(directive("style-src")).toContain("https://fonts.googleapis.com");
+  });
+
+  it("still restricts script-src to self", () => {
+    // Guard against widening the wrong directive while fixing fonts.
+    expect(directive("script-src")).toEqual(["'self'"]);
+  });
+});

--- a/src/utils/fonts.ts
+++ b/src/utils/fonts.ts
@@ -37,29 +37,29 @@ export function loadGoogleFont(fontId: string): void {
 }
 
 /**
- * Load a local font file via the browser FontFace API.
- * Uses Tauri's asset protocol (convertFileSrc) to serve the file.
- * Safe to call multiple times — loads only once per session per font name.
+ * Load an imported font file via the browser FontFace API.
+ *
+ * The bytes come back from Rust as a `data:` URL rather than through the asset
+ * protocol. The asset protocol's scope covers only the notes folder, so a font
+ * anywhere else was blocked, and its URL scheme differs per platform — a data:
+ * URL has neither problem.
+ *
+ * Safe to call repeatedly — loads once per session per font name.
  */
 export async function loadCustomFont(name: string, path: string): Promise<boolean> {
   const key = `custom:${name}`;
   if (loadedFonts.has(key)) return true;
 
   try {
-    const { convertFileSrc } = await import("@tauri-apps/api/core");
-    const url = convertFileSrc(path);
-    const face = new FontFace(name, `url("${url}")`);
+    const { invoke } = await import("@tauri-apps/api/core");
+    const dataUrl = await invoke<string>("load_font_data", { path });
+    const face = new FontFace(name, `url("${dataUrl}")`);
     await face.load();
     document.fonts.add(face);
     loadedFonts.add(key);
     return true;
   } catch {
-    return false; // file missing or format unsupported — caller handles gracefully
+    return false; // missing, moved, or unsupported — caller reports it
   }
 }
 
-/** Derive a font family name from a font file's basename (strips extension). */
-export function fontNameFromPath(path: string): string {
-  const basename = path.split("/").pop() ?? path;
-  return basename.replace(/\.[^.]+$/, "").replace(/[-_]/g, " ");
-}


### PR DESCRIPTION
Reported as "could not load this font file" on import, then: *"even the inbuilt fonts like jet brains mono dont load properly."*

That second symptom is the diagnosis. If a bundled Google font fails too, it isn't the user's file.

## Root cause

The CSP declared **no `font-src`**, so it fell back to `default-src 'self'` and every font file was blocked. Built-in fonts failed *twice*, because `style-src 'self' 'unsafe-inline'` also blocked the Google Fonts stylesheet that `loadGoogleFont()` injects.

Neither failure surfaced anywhere but a console violation, so the app just looked like it ignored the font setting.

```
- style-src 'self' 'unsafe-inline'
+ style-src 'self' 'unsafe-inline' https://fonts.googleapis.com
+ font-src  'self' data: https://fonts.gstatic.com
```

`csp.test.ts` parses the real `tauri.conf.json` and asserts both, plus that `script-src` stays `'self'` — so a future font fix can't quietly widen the wrong directive. It fails 4/5 without this change.

## Imported fonts had a second, independent bug

`loadCustomFont` served files through Tauri's asset protocol, whose scope is:

```
$DOCUMENT/Stik/**
$HOME/Library/Mobile Documents/com~apple~CloudDocs/Stik/**
```

A `.ttf` in Downloads is unreachable regardless of CSP. The protocol's URL scheme also differs per platform and only the Windows form (`http://asset.localhost`) was ever listed.

Now: `import_font_file` copies into `~/.stik/fonts`, and `load_font_data` returns a `data:` URL. No asset protocol, no scope, no per-platform scheme. Copying also fixes the fragility of storing a path into Downloads that breaks the moment the file moves.

`load_font_data` hands raw bytes to the webview, so it canonicalizes both sides and refuses anything outside `~/.stik/fonts` — the path arrives from `settings.json`, not only from the picker.

## Note for the changelog

Pre-existing `custom_fonts` entries point outside the fonts directory and need re-importing. They never rendered, so nothing working is lost.

68 Rust tests (6 new) and 141 frontend tests (5 new) pass.

## Not in here

The built-in families still load from Google's CDN, which means a network round trip on every launch and no fonts offline — worth reconsidering against the "nothing leaves your Mac" positioning. Self-hosting all nine (all SIL OFL) is ~300-500 KB of woff2. Separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)