### PR TITLE
feat(notes): opt-in simple filenames (#90)

### DIFF
--- a/src-tauri/src/commands/notes.rs
+++ b/src-tauri/src/commands/notes.rs
@@ -1,7 +1,7 @@
 use base64::Engine;
-use chrono::Local;
+use chrono::{DateTime, Local, NaiveDate};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Emitter, Manager, State};
 
 use super::analytics;
@@ -68,13 +68,78 @@ fn generate_slug(content: &str) -> String {
     }
 }
 
-/// Generate timestamp-based filename with UUID suffix to prevent collisions
-fn generate_filename(content: &str) -> String {
-    let now = Local::now();
-    let timestamp = now.format("%Y%m%d-%H%M%S").to_string();
+/// Build the on-disk name for a new note.
+///
+/// The default `YYYYMMDD-HHMMSS-<slug>-<uuid>.md` sorts chronologically in any
+/// file browser, can never collide, and carries the capture date that stats and
+/// On This Day read straight off the name.
+///
+/// With `simple_filenames` the note is just `<slug>.md`, which reads far better
+/// in Finder and Obsidian. The trade is that the name no longer carries a date,
+/// so those features fall back to the file's modification time, and a unique
+/// name has to be claimed rather than generated.
+fn generate_filename(content: &str, folder_path: &Path) -> String {
     let slug = generate_slug(content);
+
+    if simple_filenames_enabled() {
+        return claim_simple_filename(&slug, folder_path);
+    }
+
+    let timestamp = Local::now().format("%Y%m%d-%H%M%S").to_string();
     let suffix = &uuid::Uuid::new_v4().to_string()[..4];
     format!("{}-{}-{}.md", timestamp, slug, suffix)
+}
+
+fn simple_filenames_enabled() -> bool {
+    super::settings::load_settings_from_file()
+        .map(|s| s.simple_filenames)
+        .unwrap_or(false)
+}
+
+/// `note.md`, then `note-2.md`, `note-3.md`…
+///
+/// Creates the file as it goes rather than merely testing for absence: two
+/// captures in the same instant would both see the name free and the second
+/// would silently overwrite the first. `create_new` is atomic, so exactly one
+/// caller can win a given name.
+fn claim_simple_filename(slug: &str, folder_path: &Path) -> String {
+    for n in 1..=999 {
+        let candidate = if n == 1 {
+            format!("{}.md", slug)
+        } else {
+            format!("{}-{}.md", slug, n)
+        };
+
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(folder_path.join(&candidate))
+        {
+            Ok(_) => return candidate,
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            // Anything else (permissions, missing dir) is the real write's
+            // problem to report, with a better message than we could give.
+            Err(_) => return candidate,
+        }
+    }
+
+    format!("{}-{}.md", slug, &uuid::Uuid::new_v4().to_string()[..4])
+}
+
+/// The note's capture date: the filename prefix when it has one, otherwise the
+/// file's modification time. Simple filenames carry no date, so the filesystem
+/// is the only source for them.
+pub fn note_date(path: &Path, filename: &str) -> Option<NaiveDate> {
+    if let Some(segment) = filename.split('-').next() {
+        if segment.len() == 8 {
+            if let Ok(date) = NaiveDate::parse_from_str(segment, "%Y%m%d") {
+                return Some(date);
+            }
+        }
+    }
+
+    let modified = std::fs::metadata(path).ok()?.modified().ok()?;
+    Some(DateTime::<Local>::from(modified).date_naive())
 }
 
 fn is_break_placeholder_line(line: &str) -> bool {
@@ -112,7 +177,7 @@ pub fn save_note_inner(folder: String, content: String) -> Result<NoteSaved, Str
     super::storage::ensure_dir(&folder_path.to_string_lossy())?;
 
     // Generate filename and write
-    let filename = generate_filename(&content);
+    let filename = generate_filename(&content, &folder_path);
     let file_path = folder_path.join(&filename);
 
     super::storage::write_file(&file_path.to_string_lossy(), &content)?;
@@ -633,7 +698,81 @@ pub fn save_note_image_from_path(
 
 #[cfg(test)]
 mod tests {
-    use super::is_effectively_empty_markdown;
+    use super::{claim_simple_filename, is_effectively_empty_markdown, note_date};
+    use chrono::{Local, NaiveDate};
+
+    fn temp_folder(label: &str) -> std::path::PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock should be monotonic")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("stik-fname-{label}-{nanos}"));
+        std::fs::create_dir_all(&dir).expect("temp dir should be creatable");
+        dir
+    }
+
+    #[test]
+    fn simple_names_disambiguate_by_counting_up() {
+        let dir = temp_folder("collide");
+
+        assert_eq!(
+            claim_simple_filename("meeting-notes", &dir),
+            "meeting-notes.md"
+        );
+        assert_eq!(
+            claim_simple_filename("meeting-notes", &dir),
+            "meeting-notes-2.md"
+        );
+        assert_eq!(
+            claim_simple_filename("meeting-notes", &dir),
+            "meeting-notes-3.md"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn claiming_a_name_reserves_it_so_a_racing_save_cannot_overwrite() {
+        // Guards against check-then-write: two captures in the same instant
+        // would both see the name free, and the second would clobber the first.
+        let dir = temp_folder("reserve");
+        let first = claim_simple_filename("note", &dir);
+        assert!(
+            dir.join(&first).exists(),
+            "claimed name should exist on disk"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn note_date_reads_the_filename_prefix_without_touching_disk() {
+        let date = note_date(
+            std::path::Path::new("/nonexistent/20260413-160431-hello-0e29.md"),
+            "20260413-160431-hello-0e29.md",
+        );
+        assert_eq!(date, NaiveDate::from_ymd_opt(2026, 4, 13));
+    }
+
+    #[test]
+    fn note_date_falls_back_to_mtime_for_a_simple_filename() {
+        let dir = temp_folder("mtime");
+        let file = dir.join("meeting-notes.md");
+        std::fs::write(&file, "hi").unwrap();
+
+        let date = note_date(&file, "meeting-notes.md").expect("mtime should resolve");
+        assert_eq!(date, Local::now().date_naive());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn note_date_is_none_without_a_prefix_or_a_file() {
+        assert_eq!(
+            note_date(std::path::Path::new("/nonexistent/x.md"), "x.md"),
+            None
+        );
+    }
 
     #[test]
     fn placeholder_breaks_only_are_treated_as_empty() {

--- a/src-tauri/src/commands/on_this_day.rs
+++ b/src-tauri/src/commands/on_this_day.rs
@@ -119,7 +119,8 @@ fn collect_candidates(today: NaiveDate) -> Result<Vec<OnThisDayCandidate>, Strin
                     None => continue,
                 };
 
-                let Some(date) = parse_date_from_filename(filename) else {
+                // Simple filenames carry no date, so fall back to mtime.
+                let Some(date) = super::notes::note_date(&path, filename) else {
                     continue;
                 };
 
@@ -146,14 +147,6 @@ fn select_best_candidate(candidates: &[OnThisDayCandidate]) -> Option<OnThisDayC
         .iter()
         .cloned()
         .max_by_key(|candidate| candidate.date)
-}
-
-fn parse_date_from_filename(filename: &str) -> Option<NaiveDate> {
-    let date_segment = filename.split('-').next()?;
-    if date_segment.len() != 8 {
-        return None;
-    }
-    NaiveDate::parse_from_str(date_segment, "%Y%m%d").ok()
 }
 
 fn build_preview(content: &str) -> String {
@@ -221,7 +214,10 @@ mod tests {
 
     #[test]
     fn parses_date_from_filename_prefix() {
-        let date = parse_date_from_filename("20240206-101530-my-note.md");
+        let date = super::super::notes::note_date(
+            std::path::Path::new("/nonexistent/20240206-101530-my-note.md"),
+            "20240206-101530-my-note.md",
+        );
         assert_eq!(date, NaiveDate::from_ymd_opt(2024, 2, 6));
     }
 

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -183,6 +183,11 @@ pub struct StikSettings {
     pub note_lock: NoteLockSettings,
     #[serde(default)]
     pub use_directory_as_root: bool,
+    /// Save notes as `<slug>.md` instead of `YYYYMMDD-HHMMSS-<slug>-<uuid>.md`.
+    /// Nicer in Finder; costs the date-in-name that stats and On This Day read,
+    /// which then fall back to the file's modification time.
+    #[serde(default)]
+    pub simple_filenames: bool,
     #[serde(default)]
     pub dictation: DictationSettings,
     /// BCP-47 locale tag for the UI language ("en", "zh-CN").
@@ -245,6 +250,7 @@ impl Default for StikSettings {
             icloud: ICloudSettings::default(),
             note_lock: NoteLockSettings::default(),
             use_directory_as_root: false,
+            simple_filenames: false,
             dictation: DictationSettings::default(),
         }
     }

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -70,7 +70,8 @@ fn collect_note_dates() -> Result<Vec<NaiveDate>, String> {
                 }
 
                 if let Some(filename) = path.file_name().and_then(|name| name.to_str()) {
-                    if let Some(date) = parse_date_from_filename(filename) {
+                    // Simple filenames carry no date, so fall back to mtime.
+                    if let Some(date) = super::notes::note_date(&path, filename) {
                         dates.push(date);
                     }
                 }
@@ -91,15 +92,6 @@ fn get_stats_path() -> Result<PathBuf, String> {
 fn save_stats_to_file(stats: &CaptureStats) -> Result<(), String> {
     let path = get_stats_path()?;
     versioning::save_versioned(&path, stats)
-}
-
-fn parse_date_from_filename(filename: &str) -> Option<NaiveDate> {
-    let date_segment = filename.split('-').next()?;
-    if date_segment.len() != 8 {
-        return None;
-    }
-
-    NaiveDate::parse_from_str(date_segment, "%Y%m%d").ok()
 }
 
 fn compute_capture_streak_from_dates(dates: &[NaiveDate], today: NaiveDate) -> u32 {
@@ -135,7 +127,10 @@ mod tests {
 
     #[test]
     fn parses_date_from_filename_prefix() {
-        let date = parse_date_from_filename("20260206-101530-my-note.md");
+        let date = super::super::notes::note_date(
+            std::path::Path::new("/nonexistent/20260206-101530-my-note.md"),
+            "20260206-101530-my-note.md",
+        );
         assert_eq!(date, NaiveDate::from_ymd_opt(2026, 2, 6));
     }
 

--- a/src/components/SettingsContent.tsx
+++ b/src/components/SettingsContent.tsx
@@ -2096,6 +2096,28 @@ export default function SettingsContent({
           )}
 
           <div>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={settings.simple_filenames ?? false}
+                onChange={(e) =>
+                  onSettingsChange({
+                    ...settings,
+                    simple_filenames: e.target.checked,
+                  })
+                }
+                className="rounded border-line"
+              />
+              <span className="text-[12px] text-ink">
+                {t("settings.simpleFilenames")}
+              </span>
+            </label>
+            <p className="mt-1.5 text-[12px] text-stone leading-relaxed">
+              {t("settings.simpleFilenames.note")}
+            </p>
+          </div>
+
+          <div>
             <p className="text-[12px] text-stone mb-1.5">{t("settings.defaultFolder")}</p>
             <div className="max-w-[360px]">
               <Dropdown

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -434,6 +434,8 @@ export const en = {
   "common.browse": "Browse",
   "common.reset": "Reset",
   "settings.notesDirectory.asRoot": "Use directory as root (skip Stik subfolder)",
+  "settings.simpleFilenames": "Simple filenames",
+  "settings.simpleFilenames.note": "Save notes as \"meeting-notes.md\" instead of \"20260730-125367-meeting-notes-ab12.md\". Existing notes keep their names. Without the date in the filename, streaks and On This Day read the file's modification date instead.",
   "settings.defaultFolder.describe": "Opens when using tray menu or if no folder is specified.",
   "settings.textDirection.title": "Text direction",
   "settings.textDirection.describe": "Set text direction for the editor. Auto detects per line — ideal for Arabic, Hebrew, and mixed-language notes.",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -436,6 +436,8 @@ export const zhCN: Translations = {
   "common.browse": "浏览",
   "common.reset": "重置",
   "settings.notesDirectory.asRoot": "将该目录用作根目录（跳过 Stik 子文件夹）",
+  "settings.simpleFilenames": "简洁文件名",
+  "settings.simpleFilenames.note": "将笔记保存为“meeting-notes.md”，而不是“20260730-125367-meeting-notes-ab12.md”。已有笔记的名称保持不变。文件名中没有日期时，连续记录天数和“往年今日”将改用文件的修改日期。",
   "settings.defaultFolder.describe": "使用菜单栏菜单或未指定文件夹时打开。",
   "settings.textDirection.title": "文字方向",
   "settings.textDirection.describe": "设置编辑器的文字方向。“自动”会逐行检测——适合阿拉伯语、希伯来语和多语言混排的笔记。",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -105,6 +105,7 @@ export interface StikSettings {
   icloud: ICloudSettings;
   note_lock: NoteLockSettings;
   use_directory_as_root?: boolean;
+  simple_filenames?: boolean;
   dictation?: DictationSettings;
   /// BCP-47 locale tag for the UI language. "" = follow system language.
   language?: string;


### PR DESCRIPTION
Closes #90.

## It isn't a bug

The reporter's example, `125367test.md`, doesn't exist. Every one of the 111 notes I checked matches `YYYYMMDD-HHMMSS-slug-uuid.md` exactly — `20260413-160431-love-your-app-ive-been-0e29.md`. They were describing the `HHMMSS` part loosely.

The prefix is also load-bearing:

| consumer | what it reads |
|---|---|
| `stats.rs` | capture date, for the streak counter |
| `on_this_day.rs` | capture date, for On This Day |
| `index.rs` | note title, for locked notes |
| `wikiLink.ts`, `CommandPalette.tsx` | strips it for display |

So changing the default would break two features and the round-trip contract the mobile app is being built against. But wanting `meeting-notes.md` in Finder is a fair ask, so it becomes a choice instead.

## What this adds

**Off by default. Nothing migrates.** With it on, notes save as `<slug>.md`, colliding into `<slug>-2.md`, `<slug>-3.md`.

Both date readers now go through `notes::note_date`, which prefers the filename prefix and falls back to the file's mtime — so streaks and On This Day keep working for notes that no longer carry a date. The duplicated `parse_date_from_filename` in `stats.rs` and `on_this_day.rs` is gone.

## Two decisions worth reviewing

**The date does not go into frontmatter**, despite that being the obvious home for it. Nothing in the app parses frontmatter today, so a `---` block would render as literal text in the editor and be swept up by `extract_title` and the previews. Frontmatter is right, but it belongs with the stable-note-id work so it can be introduced once, not twice.

**`claim_simple_filename` uses `create_new`, not an existence check.** Check-then-write lets two captures in the same instant both see a name as free, and the second silently overwrites the first — actual note loss. Creating the file atomically means exactly one caller can win a name. There's a test for it.

## Known gap

A locked note with a simple filename shows its title with hyphens, because `index.rs` derives that from the name. Cosmetic, and `index.rs` is mid-rewrite for nested folders, so I stayed out of it.

73 Rust tests (5 new) and 141 frontend tests pass, including the en/zh-CN parity guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)