### PR TITLE
feat: clearable shortcuts, persistent Zen mode, no Zen hint (#92, #93, #94)

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -183,6 +183,10 @@ pub struct StikSettings {
     pub note_lock: NoteLockSettings,
     #[serde(default)]
     pub use_directory_as_root: bool,
+    /// Whether the capture window was last left in Zen mode. Persisted so the
+    /// mode survives a restart rather than resetting every launch.
+    #[serde(default)]
+    pub zen_mode_enabled: bool,
     /// Save notes as `<slug>.md` instead of `YYYYMMDD-HHMMSS-<slug>-<uuid>.md`.
     /// Nicer in Finder; costs the date-in-name that stats and On This Day read,
     /// which then fall back to the file's modification time.
@@ -250,6 +254,7 @@ impl Default for StikSettings {
             icloud: ICloudSettings::default(),
             note_lock: NoteLockSettings::default(),
             use_directory_as_root: false,
+            zen_mode_enabled: false,
             simple_filenames: false,
             dictation: DictationSettings::default(),
         }
@@ -551,7 +556,40 @@ pub fn export_theme_file(
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_loaded_settings, parse_color_value, ShortcutMapping, StikSettings};
+    use super::{
+        default_system_shortcuts, normalize_loaded_settings, normalize_system_shortcuts,
+        parse_color_value, ShortcutMapping, StikSettings,
+    };
+    use std::collections::HashMap;
+
+    #[test]
+    fn a_cleared_system_shortcut_survives_normalization() {
+        // Clearing is stored as an empty string. `or_insert_with` must leave it
+        // alone — if the default were restored, the Clear button (#92) would
+        // silently undo itself on the next settings load.
+        let mut shortcuts = default_system_shortcuts();
+        shortcuts.insert("voice_note".to_string(), String::new());
+
+        normalize_system_shortcuts(&mut shortcuts);
+
+        assert_eq!(shortcuts.get("voice_note").map(String::as_str), Some(""));
+        assert_eq!(
+            shortcuts.get("search").map(String::as_str),
+            Some("Cmd+Shift+P")
+        );
+    }
+
+    #[test]
+    fn a_missing_system_shortcut_still_gets_its_default() {
+        // Distinct from cleared: absent means "never set", not "unset by hand".
+        let mut shortcuts: HashMap<String, String> = HashMap::new();
+        normalize_system_shortcuts(&mut shortcuts);
+
+        assert_eq!(
+            shortcuts.get("voice_note").map(String::as_str),
+            Some("Cmd+Shift+V")
+        );
+    }
 
     #[test]
     fn normalization_reenables_all_disabled_shortcuts() {

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -132,7 +132,11 @@ const Editor = forwardRef<EditorRef, EditorProps>(
     // Subscribing to the locale is what makes this component re-render when
     // the language changes; the module-level `t` alone would not.
     const { t: translate } = useTranslation();
-    const placeholderText = placeholder || translate("editor.startTyping");
+    // `??` rather than `||`: an explicitly empty placeholder means draw
+    // nothing (Zen mode), where undefined means "use the default".
+    const placeholderText = placeholder ?? translate("editor.startTyping");
+    // Never empty — this is the editor's accessible name, not its hint.
+    const accessibleName = placeholderText || translate("editor.startTyping");
 
     const containerRef = useRef<HTMLDivElement>(null);
     const viewRef = useRef<EditorView | null>(null);
@@ -527,7 +531,9 @@ const Editor = forwardRef<EditorRef, EditorProps>(
         // @replit/codemirror-vim makes native ::selection transparent.
         // drawSelection renders .cm-selectionBackground instead.
         drawSelection(),
-        placeholderCompartment.of(accessibleEditor(placeholderText)),
+        placeholderCompartment.of(
+          accessibleEditor(placeholderText, accessibleName),
+        ),
         search(),
         richCopyHandler,
         imageHandlers,
@@ -603,10 +609,10 @@ const Editor = forwardRef<EditorRef, EditorProps>(
       if (!view) return;
       view.dispatch({
         effects: placeholderCompartment.reconfigure(
-          accessibleEditor(placeholderText),
+          accessibleEditor(placeholderText, accessibleName),
         ),
       });
-    }, [placeholderText]);
+    }, [placeholderText, accessibleName]);
     // Parent uses key={vimEnabled} to force remount when vim toggled.
 
     // Tauri native drag-drop fallback (WebKit dataTransfer can be empty for OS-level drops)

--- a/src/components/PostIt.tsx
+++ b/src/components/PostIt.tsx
@@ -288,6 +288,7 @@ export default function PostIt({
           (s.text_direction as "auto" | "ltr" | "rtl") || "auto",
         );
         setIcloudEnabled(s.icloud?.enabled ?? false);
+        setZenMode(s.zen_mode_enabled ?? false);
         setDictationActiveModel(s.dictation?.active_model ?? null);
         setDictationLanguage(s.dictation?.active_language ?? null);
       })
@@ -656,9 +657,29 @@ export default function PostIt({
     handleSaveAndClose,
   ]);
 
+  // Toggling Zen also writes it to settings so the mode survives a restart
+  // (#93). Persisting is best-effort: failing to save must never block the
+  // toggle the user just asked for.
+  const toggleZenMode = useCallback(() => {
+    setZenMode((prev) => {
+      const next = !prev;
+      invoke<StikSettings>("get_settings")
+        .then((s) =>
+          invoke("save_settings", {
+            settings: { ...s, zen_mode_enabled: next },
+          }),
+        )
+        .catch(() => {});
+      return next;
+    });
+  }, []);
+
   // Zen mode shortcut (reads from settings, defaults to Cmd+.)
   useEffect(() => {
-    const shortcutStr = systemShortcuts.zen_mode || "Cmd+Period";
+    // `??` not `||`: an empty string means the user cleared this shortcut
+    // deliberately (#92), so nothing should be bound at all.
+    const shortcutStr = systemShortcuts.zen_mode ?? "Cmd+Period";
+    if (!shortcutStr) return;
     const handleZenToggle = (e: KeyboardEvent) => {
       const parts = shortcutStr.split("+");
       const key = parts[parts.length - 1];
@@ -680,15 +701,17 @@ export default function PostIt({
       if (eventKey.toLowerCase() !== key.toLowerCase()) return;
 
       e.preventDefault();
-      setZenMode((prev) => !prev);
+      toggleZenMode();
     };
     window.addEventListener("keydown", handleZenToggle);
     return () => window.removeEventListener("keydown", handleZenToggle);
-  }, [systemShortcuts.zen_mode]);
+  }, [systemShortcuts.zen_mode, toggleZenMode]);
 
   // Dictation shortcut (reads from settings, defaults to Cmd+Shift+D)
   useEffect(() => {
-    const shortcutStr = systemShortcuts.dictation || "Cmd+Shift+D";
+        // Cleared means unbound, same as zen mode above (#92).
+    const shortcutStr = systemShortcuts.dictation ?? "Cmd+Shift+D";
+    if (!shortcutStr) return;
     const handleDictation = (e: KeyboardEvent) => {
       const parts = shortcutStr.split("+");
       const key = parts[parts.length - 1];
@@ -1862,7 +1885,14 @@ export default function PostIt({
               key={`${vimEnabled ? "vim" : "novim"}-${textDirection}`}
               ref={editorRef}
               onChange={handleContentChange}
-              placeholder={isSticked ? t("postit.stickedPlaceholder") : t("postit.typePlaceholder")}
+              placeholder={
+                // Zen mode is meant to be empty — the hint is chrome (#94).
+                zenMode
+                  ? ""
+                  : isSticked
+                    ? t("postit.stickedPlaceholder")
+                    : t("postit.typePlaceholder")
+              }
               initialContent={resolvedInitialContent || initialContent}
               vimEnabled={vimEnabled}
               showFormatToolbar={zenMode ? false : formatToolbar}

--- a/src/components/SettingsContent.tsx
+++ b/src/components/SettingsContent.tsx
@@ -21,6 +21,7 @@ import {
   SYSTEM_SHORTCUT_ACTIONS,
   SYSTEM_SHORTCUT_DEFAULTS,
   SYSTEM_SHORTCUT_LABEL_KEYS,
+  isClearableAction,
   type SystemAction,
 } from "@/utils/systemShortcuts";
 import { hexToRgb, rgbToHex } from "@/utils/color";
@@ -1902,6 +1903,38 @@ export default function SettingsContent({
                         existingShortcuts={folderShortcuts}
                       />
                     </div>
+                    {currentShortcut !== "" &&
+                      isClearableAction(action as SystemAction) && (
+                        <button
+                          type="button"
+                          onClick={() =>
+                            onSettingsChange({
+                              ...settings,
+                              system_shortcuts: {
+                                ...settings.system_shortcuts,
+                                [action]: "",
+                              },
+                            })
+                          }
+                          className="w-6 h-6 shrink-0 flex items-center justify-center rounded-md hover:bg-coral-light text-stone hover:text-coral transition-colors"
+                          title={t("settings.shortcut.clear")}
+                          aria-label={t("settings.shortcut.clear")}
+                        >
+                          <svg
+                            width="12"
+                            height="12"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          >
+                            <path d="M18 6 6 18" />
+                            <path d="m6 6 12 12" />
+                          </svg>
+                        </button>
+                      )}
                     {!isDefault && (
                       <button
                         type="button"

--- a/src/components/ShortcutRecorder.tsx
+++ b/src/components/ShortcutRecorder.tsx
@@ -314,7 +314,9 @@ export default function ShortcutRecorder({
     ? tempShortcut
       ? formatShortcutDisplay(tempShortcut)
       : t("settings.shortcut.pressKeys")
-    : formatShortcutDisplay(value);
+    : value === ""
+      ? t("settings.shortcut.notSet")
+      : formatShortcutDisplay(value);
 
   return (
     <>

--- a/src/extensions/cm-a11y.ts
+++ b/src/extensions/cm-a11y.ts
@@ -69,12 +69,17 @@ const announceEdits = EditorState.transactionExtender.of((tr) => {
  * longer re-reads it on every pause. The field instead gets a stable accessible
  * name via aria-label, announced once when focus enters.
  */
-export function accessibleEditor(placeholderText: string): Extension {
+export function accessibleEditor(
+  placeholderText: string,
+  accessibleName: string = placeholderText,
+): Extension {
   const placeholderEl = document.createElement("span");
   placeholderEl.textContent = placeholderText;
   return [
     cmPlaceholder(placeholderEl),
-    EditorView.contentAttributes.of({ "aria-label": placeholderText }),
+    // Kept separate from the visible text: Zen mode draws no placeholder but
+    // the field still has to announce itself to a screen reader.
+    EditorView.contentAttributes.of({ "aria-label": accessibleName }),
     announceEdits,
   ];
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -117,6 +117,8 @@ export const en = {
   "settings.shortcut.remove": "Remove shortcut",
   "settings.shortcut.system": "System shortcuts",
   "settings.shortcut.resetDefault": "Reset to default",
+  "settings.shortcut.clear": "Clear shortcut",
+  "settings.shortcut.notSet": "Not set",
   "settings.shortcut.clickToRecord": "Click to record",
 
   // ── Settings — window / system ────────────────────────────────────

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -120,6 +120,8 @@ export const zhCN: Translations = {
   "settings.shortcut.remove": "移除快捷键",
   "settings.shortcut.system": "系统快捷键",
   "settings.shortcut.resetDefault": "恢复默认",
+  "settings.shortcut.clear": "清除快捷键",
+  "settings.shortcut.notSet": "未设置",
   "settings.shortcut.clickToRecord": "点按以录制",
 
   // ── Settings — window / system ────────────────────────────────────

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -105,6 +105,7 @@ export interface StikSettings {
   icloud: ICloudSettings;
   note_lock: NoteLockSettings;
   use_directory_as_root?: boolean;
+  zen_mode_enabled?: boolean;
   simple_filenames?: boolean;
   dictation?: DictationSettings;
   /// BCP-47 locale tag for the UI language. "" = follow system language.

--- a/src/utils/systemShortcuts.test.ts
+++ b/src/utils/systemShortcuts.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import {
+  SYSTEM_SHORTCUT_ACTIONS,
+  getSystemShortcutValues,
+  isClearableAction,
+} from "./systemShortcuts";
+
+describe("clearing system shortcuts (#92)", () => {
+  it("lets every action be cleared except Settings", () => {
+    // Settings is the way back: the tray icon and the Dock icon can both be
+    // hidden, so unsetting this too would leave no route into Settings at all.
+    expect(isClearableAction("settings")).toBe(false);
+
+    for (const action of SYSTEM_SHORTCUT_ACTIONS) {
+      if (action === "settings") continue;
+      expect(isClearableAction(action)).toBe(true);
+    }
+  });
+
+  it("treats a cleared shortcut as reserving nothing", () => {
+    // Otherwise "" counts as a taken binding and blocks unrelated shortcuts.
+    const values = getSystemShortcutValues({
+      search: "Cmd+Shift+P",
+      voice_note: "",
+      zen_mode: "Cmd+Period",
+    });
+
+    expect(values).toEqual(["Cmd+Shift+P", "Cmd+Period"]);
+    expect(values).not.toContain("");
+  });
+
+  it("keeps every binding when nothing is cleared", () => {
+    const values = getSystemShortcutValues({
+      search: "Cmd+Shift+P",
+      manager: "Cmd+Shift+M",
+    });
+
+    expect(values).toHaveLength(2);
+  });
+});

--- a/src/utils/systemShortcuts.ts
+++ b/src/utils/systemShortcuts.ts
@@ -33,9 +33,23 @@ export const SYSTEM_SHORTCUT_LABEL_KEYS: Record<SystemAction, TranslationKey> = 
   clip_capture: "shortcut.clipCapture",
 };
 
+/**
+ * Settings deliberately cannot be cleared.
+ *
+ * The tray icon and the Dock icon can both be hidden, so if the Settings
+ * shortcut were also unset there would be no way left to reach Settings and
+ * undo any of it. Every other action has a menu or is simply optional.
+ */
+export const UNCLEARABLE_ACTIONS: readonly SystemAction[] = ["settings"];
+
+export function isClearableAction(action: SystemAction): boolean {
+  return !UNCLEARABLE_ACTIONS.includes(action);
+}
+
 /** Get all system shortcut values for use as reserved list */
 export function getSystemShortcutValues(
   systemShortcuts: Record<string, string>,
 ): string[] {
-  return Object.values(systemShortcuts);
+  // Cleared shortcuts are the empty string; they reserve nothing.
+  return Object.values(systemShortcuts).filter((value) => value !== "");
 }


### PR DESCRIPTION
Three requests from @clementaudic, all on the Zen-mode/shortcuts surface.

Closes #92, closes #93, closes #94.

## #92 — Clear button per system shortcut

Each row gets a Clear button that stores `""`. That value survives `normalize_system_shortcuts` because it uses `or_insert_with` (an entry that exists is left alone), and `parse_shortcut_string` rejects it, so nothing is registered globally.

Two in-app handlers in `PostIt.tsx` read the value with `||`, which treated a deliberately cleared shortcut as unset and silently restored the default. Both now use `??` and bail when empty.

**Settings is deliberately not clearable** — the reporter raised this risk themselves in #93. `hide_dock_icon` and `hide_tray_icon` both exist, so if the Settings shortcut could also be unset there'd be no route left into Settings to undo any of it. Every other action is optional or reachable another way. There's a test pinning this.

## #93 — Zen mode survives a restart

New `zen_mode_enabled` setting, restored on load and written on toggle.

Restored **only from the initial settings read**, not from the `settings-changed` event — a save in another window shouldn't yank someone into or out of Zen mid-sentence. Persisting is best-effort and never blocks the toggle the user just asked for.

I went with "remember the last mode" rather than the alternative "default to Zen" option, since it's what the issue title asks for and needs no extra setting.

## #94 — No placeholder hint in Zen mode

Zen passes an empty placeholder. `Editor` now reads it with `??` so an explicit `""` means *draw nothing*, while `undefined` still means *use the default*.

Worth a look: `accessibleEditor` now takes the accessible name **separately** from the visible hint. Hiding the placeholder would otherwise have emptied the editor's `aria-label` too, silently costing VoiceOver users the field's name — the opposite of what the a11y work in #87 just added.

## Tests

75 Rust (2 new), 144 frontend (3 new). The new ones cover the two things that would regress silently: a cleared shortcut surviving normalization, and Settings staying unclearable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)