### PR TITLE
fix: physical-key shortcut matching (#96) and themed accent tints (#97)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
+import { matchesEitherPrimary } from "@/utils/matchShortcut";
 import { listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
@@ -265,7 +266,7 @@ export default function App() {
     if (windowInfo.type !== "postit") return;
 
     const handleKeyDown = async (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === ",") {
+      if (matchesEitherPrimary("Cmd+Shift+Comma", e)) {
         e.preventDefault();
         try {
           await invoke("open_settings");

--- a/src/components/AiMenu.tsx
+++ b/src/components/AiMenu.tsx
@@ -212,7 +212,7 @@ export default function AiMenu({
                 {organizeResult.suggested_folder && (
                   <div className="flex items-center gap-2">
                     <span className="text-[10px] text-stone">{t("ai.folder")}</span>
-                    <span className="text-[11px] font-medium text-ink px-1.5 py-0.5 bg-coral/10 rounded">
+                    <span className="text-[11px] font-medium text-ink px-1.5 py-0.5 bg-coral-light rounded">
                       {organizeResult.suggested_folder}
                     </span>
                   </div>

--- a/src/components/PostIt.tsx
+++ b/src/components/PostIt.tsx
@@ -1632,7 +1632,7 @@ export default function PostIt({
                       onFolderChange(suggestedFolder);
                       setSuggestedFolder(null);
                     }}
-                    className="flex items-center gap-1 px-2 py-0.5 rounded-pill text-[10px] font-medium bg-coral/10 text-coral hover:bg-coral/20 transition-colors"
+                    className="flex items-center gap-1 px-2 py-0.5 rounded-pill text-[10px] font-medium bg-coral-light text-coral hover:bg-coral/20 transition-colors"
                   >
                     <span>→</span>
                     <span>{suggestedFolder}?</span>

--- a/src/components/PostIt.tsx
+++ b/src/components/PostIt.tsx
@@ -23,6 +23,7 @@ import {
   normalizeMarkdownForCopy,
 } from "@/utils/normalizeMarkdownForCopy";
 import { shouldSaveOnGlobalEscape } from "@/utils/captureEscape";
+import { matchesShortcut } from "@/utils/matchShortcut";
 import { isCaptureSlashQuery } from "@/utils/slashQuery";
 import { markdownToPlainText } from "@/utils/markdownToHtml";
 import { shouldOpenVimCommandBar } from "@/utils/vimCommandKey";
@@ -681,24 +682,7 @@ export default function PostIt({
     const shortcutStr = systemShortcuts.zen_mode ?? "Cmd+Period";
     if (!shortcutStr) return;
     const handleZenToggle = (e: KeyboardEvent) => {
-      const parts = shortcutStr.split("+");
-      const key = parts[parts.length - 1];
-      const needsMeta = parts.some(
-        (p) => p === "Cmd" || p === "Command" || p === "Meta",
-      );
-      const needsShift = parts.some((p) => p === "Shift");
-      const needsAlt = parts.some((p) => p === "Alt" || p === "Option");
-      const needsCtrl = parts.some((p) => p === "Ctrl" || p === "Control");
-
-      if (needsMeta !== e.metaKey) return;
-      if (needsShift !== e.shiftKey) return;
-      if (needsAlt !== e.altKey) return;
-      if (needsCtrl !== e.ctrlKey) return;
-
-      // Match the key portion
-      const eventKey =
-        e.key === "." ? "Period" : e.key === "," ? "Comma" : e.key;
-      if (eventKey.toLowerCase() !== key.toLowerCase()) return;
+      if (!matchesShortcut(shortcutStr, e)) return;
 
       e.preventDefault();
       toggleZenMode();
@@ -709,27 +693,11 @@ export default function PostIt({
 
   // Dictation shortcut (reads from settings, defaults to Cmd+Shift+D)
   useEffect(() => {
-        // Cleared means unbound, same as zen mode above (#92).
+    // Cleared means unbound, same as zen mode above (#92).
     const shortcutStr = systemShortcuts.dictation ?? "Cmd+Shift+D";
     if (!shortcutStr) return;
     const handleDictation = (e: KeyboardEvent) => {
-      const parts = shortcutStr.split("+");
-      const key = parts[parts.length - 1];
-      const needsMeta = parts.some(
-        (p) => p === "Cmd" || p === "Command" || p === "Meta",
-      );
-      const needsShift = parts.some((p) => p === "Shift");
-      const needsAlt = parts.some((p) => p === "Alt" || p === "Option");
-      const needsCtrl = parts.some((p) => p === "Ctrl" || p === "Control");
-
-      if (needsMeta !== e.metaKey) return;
-      if (needsShift !== e.shiftKey) return;
-      if (needsAlt !== e.altKey) return;
-      if (needsCtrl !== e.ctrlKey) return;
-
-      const eventKey =
-        e.key === "." ? "Period" : e.key === "," ? "Comma" : e.key;
-      if (eventKey.toLowerCase() !== key.toLowerCase()) return;
+      if (!matchesShortcut(shortcutStr, e)) return;
 
       e.preventDefault();
       speechRef.current?.toggle();

--- a/src/components/SettingsContent.tsx
+++ b/src/components/SettingsContent.tsx
@@ -2628,7 +2628,7 @@ export default function SettingsContent({
           )}
 
           {/* GitHub credentials tip */}
-          <div className="p-3 bg-coral-light/35 border border-coral/20 rounded-xl space-y-1">
+          <div className="p-3 bg-coral-light/40 border border-coral/20 rounded-xl space-y-1">
             <p className="text-[12px] font-semibold text-ink">
               {t("settings.git.accountSetup")}
             </p>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -469,7 +469,7 @@ export default function SettingsModal({
               onClick={() => setActiveTab(tab.id)}
               className={`flex items-center gap-1 px-2 py-1.5 text-[12px] font-medium rounded-lg transition-colors whitespace-nowrap ${
                 isActive
-                  ? "text-coral bg-coral/10"
+                  ? "text-coral bg-coral-light"
                   : "text-stone hover:text-ink hover:bg-line/50"
               }`}
             >
@@ -538,7 +538,7 @@ export default function SettingsModal({
               </h2>
               {betaLabel && (
                 <span
-                  className="px-1.5 py-0.5 rounded-md bg-coral/15 text-coral text-[9px] font-bold tracking-wide"
+                  className="px-1.5 py-0.5 rounded-md bg-coral-light text-coral text-[9px] font-bold tracking-wide"
                   title={`${t("settings.betaBuild")} — v${appVersion}`}
                 >
                   {betaLabel}
@@ -609,7 +609,7 @@ export default function SettingsModal({
               </h2>
               {betaLabel && (
                 <span
-                  className="px-1.5 py-0.5 rounded-md bg-coral/15 text-coral text-[9px] font-bold tracking-wide"
+                  className="px-1.5 py-0.5 rounded-md bg-coral-light text-coral text-[9px] font-bold tracking-wide"
                   title={`${t("settings.betaBuild")} — v${appVersion}`}
                 >
                   {betaLabel}

--- a/src/components/ShortcutRecorder.tsx
+++ b/src/components/ShortcutRecorder.tsx
@@ -329,7 +329,7 @@ export default function ShortcutRecorder({
           }}
           className={`w-full px-3 py-2.5 rounded-lg text-[13px] text-left flex items-center justify-between transition-all ${
             isRecording
-              ? "bg-coral/10 border-2 border-coral text-coral"
+              ? "bg-coral-light border-2 border-coral text-coral"
               : "bg-bg border border-line text-ink hover:border-coral/50"
           }`}
         >

--- a/src/components/command-palette/FolderSidebar.tsx
+++ b/src/components/command-palette/FolderSidebar.tsx
@@ -60,7 +60,7 @@ export default function FolderSidebar({
             selectedFolder === null
               ? focused
                 ? "bg-coral text-white"
-                : "bg-coral/10 text-coral"
+                : "bg-coral-light text-coral"
               : "text-ink hover:bg-line/50"
           }`}
         >
@@ -94,7 +94,7 @@ export default function FolderSidebar({
                     isSelected
                       ? focused
                         ? "bg-coral text-white"
-                        : "bg-coral/10 text-coral"
+                        : "bg-coral-light text-coral"
                       : "text-ink"
                   }`}
                 >
@@ -135,7 +135,7 @@ export default function FolderSidebar({
                     isSelected
                       ? focused
                         ? "bg-coral text-white"
-                        : "bg-coral/10 text-coral"
+                        : "bg-coral-light text-coral"
                       : "text-ink hover:bg-line/50"
                   }`}
                 >
@@ -200,7 +200,7 @@ export default function FolderSidebar({
       {/* Create folder input */}
       {isCreating ? (
         <div className="border-t border-line">
-          <div className="px-3 py-2 flex items-center gap-2 bg-coral/10">
+          <div className="px-3 py-2 flex items-center gap-2 bg-coral-light">
             <span className="text-coral text-[10px]">+</span>
             <input
               type="text"

--- a/src/components/command-palette/NoteList.tsx
+++ b/src/components/command-palette/NoteList.tsx
@@ -243,7 +243,7 @@ export default function NoteList({
                   <span className="text-[10px] text-stone font-mono">
                     {formatRelativeDate(result.created)}
                   </span>
-                  <span className="px-1.5 py-0.5 rounded text-[9px] font-medium bg-coral/10 text-coral">
+                  <span className="px-1.5 py-0.5 rounded text-[9px] font-medium bg-coral-light text-coral">
                     {t("palette.matchPercent", {
                       percent: Math.round(result.similarity * 100),
                     })}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -75,7 +75,7 @@ const CommandItem = React.forwardRef<
 >(({ className = "", ...props }, ref) => (
   <CommandPrimitive.Item
     ref={ref}
-    className={`relative flex cursor-pointer select-none items-center rounded-md px-3 py-2 text-[13px] outline-none data-[selected=true]:bg-coral/10 data-[selected=true]:text-coral data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 ${className}`}
+    className={`relative flex cursor-pointer select-none items-center rounded-md px-3 py-2 text-[13px] outline-none data-[selected=true]:bg-coral-light data-[selected=true]:text-coral data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 ${className}`}
     {...props}
   />
 ));

--- a/src/extensions/cm-theme.ts
+++ b/src/extensions/cm-theme.ts
@@ -41,10 +41,10 @@ export const stikEditorTheme = EditorView.theme({
     borderLeftWidth: "1px",
   },
   ".cm-selectionBackground": {
-    backgroundColor: "rgba(232, 112, 95, 0.15) !important",
+    backgroundColor: "rgba(var(--color-coral), 0.15) !important",
   },
   "&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground": {
-    backgroundColor: "rgba(232, 112, 95, 0.2) !important",
+    backgroundColor: "rgba(var(--color-coral), 0.2) !important",
   },
   ".cm-activeLine": {
     backgroundColor: "transparent",
@@ -69,7 +69,7 @@ export const stikEditorTheme = EditorView.theme({
     transition: "background-color 0.15s",
   },
   ".cm-wikilink:hover": {
-    backgroundColor: "rgba(232, 112, 95, 0.1)",
+    backgroundColor: "rgba(var(--color-coral), 0.1)",
   },
   // Autocomplete panel
   ".cm-tooltip-autocomplete": {
@@ -100,7 +100,7 @@ export const stikEditorTheme = EditorView.theme({
     fontSize: "10px",
     fontWeight: "600",
     color: "rgb(var(--color-coral))",
-    backgroundColor: "rgba(232, 112, 95, 0.1)",
+    backgroundColor: "rgba(var(--color-coral), 0.1)",
     padding: "1px 6px",
     borderRadius: "99px",
     marginLeft: "8px",
@@ -111,11 +111,11 @@ export const stikEditorTheme = EditorView.theme({
     borderBottom: "1px solid rgb(var(--color-line))",
   },
   ".cm-searchMatch": {
-    backgroundColor: "rgba(232, 112, 95, 0.2)",
+    backgroundColor: "rgba(var(--color-coral), 0.2)",
     borderRadius: "2px",
   },
   ".cm-searchMatch.cm-searchMatch-selected": {
-    backgroundColor: "rgba(232, 112, 95, 0.35)",
+    backgroundColor: "rgba(var(--color-coral), 0.35)",
   },
   // Horizontal rule widget
   ".cm-hr-widget": {
@@ -178,7 +178,7 @@ export const stikEditorTheme = EditorView.theme({
     opacity: "1",
   },
   ".cm-table-add-row:hover": {
-    backgroundColor: "rgba(232, 112, 95, 0.1)",
+    backgroundColor: "rgba(var(--color-coral), 0.1)",
     color: "rgb(var(--color-coral))",
   },
   // Add column button — vertical bar on right edge
@@ -201,7 +201,7 @@ export const stikEditorTheme = EditorView.theme({
     opacity: "1",
   },
   ".cm-table-add-col:hover": {
-    backgroundColor: "rgba(232, 112, 95, 0.1)",
+    backgroundColor: "rgba(var(--color-coral), 0.1)",
     color: "rgb(var(--color-coral))",
   },
   // Table context menu (right-click)
@@ -228,7 +228,7 @@ export const stikEditorTheme = EditorView.theme({
     lineHeight: "1.4",
   },
   ".cm-table-menu-item:hover": {
-    backgroundColor: "rgba(232, 112, 95, 0.1)",
+    backgroundColor: "rgba(var(--color-coral), 0.1)",
     color: "rgb(var(--color-coral))",
   },
   ".cm-table-menu-disabled": {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -499,7 +499,7 @@ body,
 }
 
 .link-popover-save:hover {
-  background: rgba(232, 112, 95, 0.1);
+  background: rgba(var(--color-coral), 0.1);
 }
 
 /* ── Formatting Toolbar ── */

--- a/src/themes/ThemeProvider.tsx
+++ b/src/themes/ThemeProvider.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, type ReactNode } from "react";
+import { matchesEitherPrimary } from "@/utils/matchShortcut";
 import { invoke } from "@tauri-apps/api/core";
 import { emit } from "@tauri-apps/api/event";
 import type { StikSettings } from "@/types";
@@ -51,13 +52,16 @@ export default function ThemeProvider({ children }: Props) {
         return;
       }
 
-      // Cmd/Ctrl+Shift+D toggles dark mode.
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "d") {
+      // Cmd/Ctrl+Shift+D toggles dark mode. Matched by physical key so it
+      // lands in the same place on AZERTY and friends (#96).
+      if (matchesEitherPrimary("Cmd+Shift+D", e)) {
         e.preventDefault();
         toggleTheme();
         return;
       }
-      if ((e.metaKey || e.ctrlKey) && e.altKey && e.key === "d") {
+      // Cmd/Ctrl+Alt+D never fired before: macOS yields "\u2202" for that
+      // combination, so the old `e.key === "d"` test could never match.
+      if (matchesEitherPrimary("Cmd+Alt+D", e)) {
         e.preventDefault();
         toggleTheme();
       }

--- a/src/utils/matchShortcut.test.ts
+++ b/src/utils/matchShortcut.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import {
+  matchesShortcut,
+  matchesEitherPrimary,
+  parseShortcut,
+} from "./matchShortcut";
+
+/**
+ * Builds the event shape the matcher reads. `code` is the physical key; `key`
+ * is deliberately absent, because relying on it is the bug under test.
+ */
+function ev(
+  code: string,
+  mods: Partial<{
+    meta: boolean;
+    ctrl: boolean;
+    shift: boolean;
+    alt: boolean;
+  }> = {},
+) {
+  return {
+    code,
+    metaKey: mods.meta ?? false,
+    ctrlKey: mods.ctrl ?? false,
+    shiftKey: mods.shift ?? false,
+    altKey: mods.alt ?? false,
+  };
+}
+
+describe("matchesShortcut (#96)", () => {
+  it("matches on physical position, so AZERTY behaves like QWERTY", () => {
+    // The reported bug: an AZERTY user pressing the key labelled "M" produces
+    // e.key = "," while e.code stays KeyM. Matching the code makes the binding
+    // land on the same physical key on every layout.
+    expect(
+      matchesShortcut("Cmd+Shift+M", ev("KeyM", { meta: true, shift: true })),
+    ).toBe(true);
+  });
+
+  it("fires Cmd+Alt+D, which the e.key comparison could never match", () => {
+    // macOS yields "∂" for Cmd+Alt+D on US, ABC, Italian and French layouts,
+    // so `e.key === "d"` was dead everywhere.
+    expect(
+      matchesShortcut("Cmd+Alt+D", ev("KeyD", { meta: true, alt: true })),
+    ).toBe(true);
+  });
+
+  it("matches punctuation by position", () => {
+    expect(matchesShortcut("Cmd+Period", ev("Period", { meta: true }))).toBe(
+      true,
+    );
+    expect(
+      matchesShortcut(
+        "Cmd+Shift+Comma",
+        ev("Comma", { meta: true, shift: true }),
+      ),
+    ).toBe(true);
+  });
+
+  it("requires modifiers to match exactly", () => {
+    // Cmd+Shift+P must not fire when Alt is also down.
+    expect(
+      matchesShortcut(
+        "Cmd+Shift+P",
+        ev("KeyP", { meta: true, shift: true, alt: true }),
+      ),
+    ).toBe(false);
+    expect(matchesShortcut("Cmd+Shift+P", ev("KeyP", { meta: true }))).toBe(
+      false,
+    );
+  });
+
+  it("does not match a different physical key", () => {
+    expect(
+      matchesShortcut("Cmd+Shift+M", ev("Comma", { meta: true, shift: true })),
+    ).toBe(false);
+  });
+
+  it("never matches a cleared shortcut", () => {
+    // #92 made empty mean "unbound"; it must not become a wildcard.
+    expect(matchesShortcut("", ev("KeyM", { meta: true }))).toBe(false);
+  });
+
+  it("never matches a token that has no physical key", () => {
+    // The recorder's e.key.toUpperCase() fallback can store "@", which Rust
+    // cannot register either. It must be inert, not throw and not match.
+    expect(parseShortcut("Cmd+Shift+@")).toBeNull();
+    expect(
+      matchesShortcut("Cmd+Shift+@", ev("Digit2", { meta: true, shift: true })),
+    ).toBe(false);
+  });
+
+  it("expands arrows and digits back to their codes", () => {
+    expect(parseShortcut("Cmd+Up")?.code).toBe("ArrowUp");
+    expect(parseShortcut("Cmd+1")?.code).toBe("Digit1");
+    expect(parseShortcut("Cmd+F5")?.code).toBe("F5");
+  });
+});
+
+describe("matchesEitherPrimary", () => {
+  it("accepts Cmd or Ctrl for the built-in bindings that always have", () => {
+    expect(
+      matchesEitherPrimary(
+        "Cmd+Shift+D",
+        ev("KeyD", { meta: true, shift: true }),
+      ),
+    ).toBe(true);
+    expect(
+      matchesEitherPrimary(
+        "Cmd+Shift+D",
+        ev("KeyD", { ctrl: true, shift: true }),
+      ),
+    ).toBe(true);
+  });
+
+  it("still needs a primary modifier", () => {
+    expect(
+      matchesEitherPrimary("Cmd+Shift+D", ev("KeyD", { shift: true })),
+    ).toBe(false);
+  });
+});

--- a/src/utils/matchShortcut.ts
+++ b/src/utils/matchShortcut.ts
@@ -1,0 +1,129 @@
+/**
+ * One place that decides whether a keyboard event matches a stored shortcut.
+ *
+ * Shortcuts are stored by PHYSICAL key: the recorder builds the string from
+ * `e.code` (`KeyM` -> `"M"`) and Rust registers it as a `Code`. So matching has
+ * to compare `e.code` as well.
+ *
+ * Handlers that compared `e.key` were reading the *character the layout
+ * produces* instead of the key's position. On AZERTY the physical KeyM prints
+ * ",", which is why Cmd+Shift+M only fired when the user pressed the key
+ * labelled "," (#96). The same mistake makes Cmd+Alt+D unreachable on every
+ * layout, because macOS yields "∂" for that combination.
+ */
+
+/** Tokens that are already a `KeyboardEvent.code`. */
+const VERBATIM_CODES = new Set([
+  "Space",
+  "Enter",
+  "Backspace",
+  "Tab",
+  "Escape",
+  "Comma",
+  "Period",
+  "Slash",
+  "Backslash",
+  "BracketLeft",
+  "BracketRight",
+  "Semicolon",
+  "Quote",
+  "Backquote",
+  "Minus",
+  "Equal",
+]);
+
+/** The recorder shortens the arrow codes; expand them back. */
+const ARROW_CODES: Record<string, string> = {
+  Up: "ArrowUp",
+  Down: "ArrowDown",
+  Left: "ArrowLeft",
+  Right: "ArrowRight",
+};
+
+export interface ParsedShortcut {
+  meta: boolean;
+  ctrl: boolean;
+  shift: boolean;
+  alt: boolean;
+  /** A `KeyboardEvent.code` value, e.g. "KeyM". */
+  code: string;
+}
+
+/** Turn the stored key token back into the `KeyboardEvent.code` it came from. */
+function tokenToCode(token: string): string | null {
+  if (/^[A-Za-z]$/.test(token)) return `Key${token.toUpperCase()}`;
+  if (/^[0-9]$/.test(token)) return `Digit${token}`;
+  if (ARROW_CODES[token]) return ARROW_CODES[token];
+  if (VERBATIM_CODES.has(token)) return token;
+  if (/^F\d{1,2}$/.test(token)) return token;
+
+  // The recorder falls back to `e.key.toUpperCase()` for keys it cannot map,
+  // producing tokens like "@" that correspond to no code. Rust cannot register
+  // those either, so they must never match rather than matching by accident.
+  return null;
+}
+
+export function parseShortcut(shortcut: string): ParsedShortcut | null {
+  if (!shortcut) return null;
+
+  const parts = shortcut.split("+");
+  const token = parts[parts.length - 1];
+  const modifiers = parts.slice(0, -1);
+
+  const code = tokenToCode(token);
+  if (!code) return null;
+
+  return {
+    meta: modifiers.some((p) => p === "Cmd" || p === "Command" || p === "Meta"),
+    ctrl: modifiers.some((p) => p === "Ctrl" || p === "Control"),
+    shift: modifiers.includes("Shift"),
+    alt: modifiers.some((p) => p === "Alt" || p === "Option"),
+    code,
+  };
+}
+
+/**
+ * True when the event is exactly this shortcut. Modifiers must match exactly,
+ * so Cmd+Shift+P does not fire on Cmd+Shift+Alt+P.
+ */
+export function matchesShortcut(
+  shortcut: string,
+  event: Pick<
+    KeyboardEvent,
+    "code" | "metaKey" | "ctrlKey" | "shiftKey" | "altKey"
+  >,
+): boolean {
+  const parsed = parseShortcut(shortcut);
+  if (!parsed) return false;
+
+  return (
+    parsed.meta === event.metaKey &&
+    parsed.ctrl === event.ctrlKey &&
+    parsed.shift === event.shiftKey &&
+    parsed.alt === event.altKey &&
+    parsed.code === event.code
+  );
+}
+
+/**
+ * True when the event matches with either Cmd or Ctrl as the primary modifier.
+ * Used by the few built-in bindings that have always accepted both.
+ */
+export function matchesEitherPrimary(
+  shortcut: string,
+  event: Pick<
+    KeyboardEvent,
+    "code" | "metaKey" | "ctrlKey" | "shiftKey" | "altKey"
+  >,
+): boolean {
+  const parsed = parseShortcut(shortcut);
+  if (!parsed) return false;
+
+  const primaryHeld = event.metaKey || event.ctrlKey;
+  return (
+    primaryHeld &&
+    parsed.shift === event.shiftKey &&
+    parsed.alt === event.altKey &&
+    parsed.code === event.code
+  );
+}


### PR DESCRIPTION
Two reports from @clementaudic. Closes #97; #96 is half done and the remainder is described below.

---

## #96 — the reported symptom is real, the cause isn't display

Reported as *"Cmd+Shift+M needs Cmd+Shift+, on AZERTY"*. Stik had **two shortcut engines that disagreed**.

The global path is already layout-independent: `ShortcutRecorder` builds the stored string from `e.code`, Rust registers it as a `Code`, so the binding sits at a fixed physical position. But `zen_mode` and `dictation` are `local_only_actions` — never registered globally — and `PostIt` hand-rolled a second matcher comparing **`e.key`**, the character the layout produces. On AZERTY the physical `KeyM` prints `,`, so the two engines disagreed about the same stored string.

All five hand-rolled matchers now go through `utils/matchShortcut.ts`, which normalises the stored token back to a `KeyboardEvent.code`.

**`Cmd+Alt+D` was dead on every layout**, not just AZERTY — macOS yields `∂`, so `e.key === "d"` could never be true. I checked this with a `UCKeyTranslate` probe against US, ABC, Italian and French rather than trusting the spec. `Cmd+Shift+D` does work today (WebKit exposes the unshifted plane for Cmd+Shift), so please don't read this as "dark mode was broken" — it's a layout fix plus one genuinely dead Alt binding.

### What's still open on #96

Displaying the character **your** layout prints on the key cap. `navigator.keyboard.getLayoutMap()` would make this trivial but Safari/WKWebView has never supported it (caniuse: not supported through 26.5). The real route is `TISGetInputSourceProperty` + `UCKeyTranslate` from Rust, no new crates needed. Worth doing, but it's a separate change — and note Raycast ships exactly this model (physical binding, layout-aware label).

---

## #97 — tinted surfaces now follow the accent

Twelve surface tints move from `bg-coral/10` (Tailwind opacity over `--color-coral`) to `bg-coral-light` (the themed token): the selected tab, both BETA pills, ShortcutRecorder's recording state, the AI menu badge, the PostIt pill, the cmdk selected row, four FolderSidebar rows, the NoteList badge.

**Three are deliberately left alone.** NoteList's two selected rows and AppleNotesPicker's contain folder badges whose preset `badgeBg` is already `bg-coral-light`. Converting the row makes row and badge byte-identical — contrast 1.00, badge invisible, in every theme. That needs a design answer, so it's a follow-up rather than a silent regression.

### The bigger half of your point

> Maybe, more generally, for color consistency, color opacity modifications should be avoided.

The editor theme hardcoded `rgba(232, 112, 95, …)` **nine times** — text selection, search matches, table controls. In nord or tokyo-night your selection stayed salmon on a cold blue editor regardless of theme. All nine now use `rgba(var(--color-coral), …)`, which `cm-theme.ts:40` was already doing one line above the first offender. Same for `.link-popover-save:hover`.

The problem was never the alpha; it was the hardcoded channels underneath it.

### One thing I deliberately did not change

Your screenshot calls the escape button keeping its `accent_light` **"as expected"** — so your model is that `accent_light` is set independently and everything tinted should use it. I therefore did *not* make `accent_light` re-derive from `accent`, which would have changed the behaviour you called correct. Separately worth knowing: custom themes seed `accent_light` from the default light theme and never re-derive it, so a custom dark theme starts with a pale pink tint until you set it.

### Honest note on contrast

Selected-tab luminance contrast against the `bg-line/20` strip drops slightly in 8 of 9 themes (nord 1.22 → 1.05). Both are ~1.0, so the tint was never carrying the affordance — `text-coral` vs `text-stone` is — and theme-consistency is the better trade. Flagging it so it's a decision, not a surprise.

154 frontend tests (10 new) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)