### PR TITLE
fix: guide first note creation in an empty vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Chinese, makes privacy choices explicit, and reduces repeated work in search.
 
 ### Fixed
 
+- In the full editor, creating a note with no folders now opens the folder-name field instead of silently doing nothing. The empty state explains the prerequisite; cancelled setup does not recreate default folders. ([#109](https://github.com/0xMassi/stik_app/issues/109))
 - **Drafts during navigation and quit:** pending edits are saved before switching notes, file actions, or closing the full editor. Orderly application quit coordinates saves across capture, pinned, viewing, and full-editor windows; failed or unacknowledged saves cancel quit and leave drafts available for retry.
 - **Stale documents after reselecting a note:** explicitly reopening the same note now loads its latest saved revision into the editor. Folder/note lists and active search also refresh after native focus and external-file events without replacing a live draft.
 - **Unpinning into an occupied capture:** the original capture draft is saved before the incoming note is accepted. If that save or transfer fails, the source pin remains. Pin/unpin handoffs also preserve late input, prevent overlapping dictation, and retain retry state.

--- a/src/components/EditorWindow.persistence.test.tsx
+++ b/src/components/EditorWindow.persistence.test.tsx
@@ -56,6 +56,7 @@ const alpha = "/vault/Inbox/alpha.md";
 const beta = "/vault/Inbox/beta.md";
 const locked = "/vault/Inbox/locked.md";
 let files: Map<string, string>;
+let folders: string[];
 let failSaves: boolean;
 
 function deferred<T>() {
@@ -69,6 +70,7 @@ beforeEach(() => {
   Range.prototype.getClientRects = () => [] as unknown as DOMRectList;
   Range.prototype.getBoundingClientRect = () => new DOMRect();
   files = new Map([[alpha, "# Alpha\nOriginal A"], [beta, "# Beta\nOriginal B"], [locked, "---stik-locked---\nnonce: encrypted\nciphertext"]]);
+  folders = ["Inbox", "Other"];
   failSaves = false;
   native.closed = false;
   native.quitApproved = false;
@@ -83,7 +85,11 @@ beforeEach(() => {
       if (!saved) native.cancelQuitHandler?.({ payload: { id } });
       return null;
     }
-    if (command === "list_folders") return ["Inbox", "Other"];
+    if (command === "list_folders") return [...folders];
+    if (command === "create_folder") {
+      folders.push((args as { name: string }).name);
+      return null;
+    }
     if (command === "get_settings") return { folder_colors: {}, folder_icons: {}, load_remote_images: false };
     if (command === "list_notes") {
       const folder = (args as { folder: string }).folder;
@@ -149,6 +155,37 @@ function documentText() { return screen.getByRole("textbox", { name: "Start writ
 async function autosave() { await act(async () => { await new Promise((resolve) => setTimeout(resolve, 650)); }); }
 
 describe("full editor persistence", () => {
+  it.each(["New note", "+ New folder"])("guides %s through explicit folder creation in an empty vault", async (action) => {
+    folders = [];
+    files.clear();
+    await act(async () => { render(<EditorWindow />); });
+    expect(invoke).not.toHaveBeenCalledWith("create_folder", expect.anything());
+    fireEvent.click(screen.getByRole("button", { name: action }));
+    const name = screen.getByPlaceholderText("Folder name…");
+    expect(name).toHaveFocus();
+    fireEvent.change(name, { target: { value: "My notes" } });
+    await act(async () => { fireEvent.keyDown(name, { key: "Enter" }); });
+    expect(screen.getByRole("button", { name: /My notes/ })).toBeInTheDocument();
+    await act(async () => { fireEvent.click(screen.getByRole("button", { name: "New note" })); });
+    expect(documentText()).toContain("Untitled");
+    edit("First note in my chosen folder");
+    await act(requestClose);
+    expect(files.get("/vault/My notes/new.md")).toBe("First note in my chosen folder");
+  });
+
+  it("does not create a folder when the empty-vault prompt is cancelled", async () => {
+    folders = [];
+    files.clear();
+    await act(async () => { render(<EditorWindow />); });
+    fireEvent.click(screen.getByRole("button", { name: "New note" }));
+    const name = screen.getByPlaceholderText("Folder name…");
+    fireEvent.change(name, { target: { value: "Cancelled folder" } });
+    fireEvent.keyDown(name, { key: "Escape" });
+    expect(screen.queryByPlaceholderText("Folder name…")).not.toBeInTheDocument();
+    expect(invoke).not.toHaveBeenCalledWith("create_folder", expect.anything());
+    expect(invoke).not.toHaveBeenCalledWith("save_note", expect.anything());
+  });
+
   it("reloads the same note before editing a revision saved in another window", async () => {
     render(<EditorWindow />);
     await open("Alpha");

--- a/src/components/EditorWindow.tsx
+++ b/src/components/EditorWindow.tsx
@@ -421,7 +421,12 @@ export default function EditorWindow() {
   );
 
   const handleNewNote = useCallback(async () => {
-    if (!activeFolder) return;
+    if (!activeFolder) {
+      setFolderMenuOpen(true);
+      setAddingUnder("");
+      setNewFolder("");
+      return;
+    }
     const seed = "# Untitled\n\n";
     try {
       await withSavedNote(async () => {
@@ -1046,8 +1051,8 @@ export default function EditorWindow() {
             <Editor key={`${activePath}:${noteRevision}`} ref={editorRef} initialContent={content} onChange={handleChange} placeholder="Start writing…" showFormatToolbar loadRemoteImages={loadRemoteImages} />
           ) : (
             <div className="flex-1 flex flex-col items-center justify-center gap-3 text-stone">
-              <p className="text-sm">{t("editor.selectOrCreate")}</p>
-              <button onClick={handleNewNote} className="px-3 py-1.5 text-sm rounded-lg bg-coral/10 text-coral hover:bg-coral/20 transition-colors">+ {t("editor.newNote")}</button>
+              <p className="text-sm">{t(activeFolder ? "editor.selectOrCreate" : "editor.createFolderFirst")}</p>
+              <button type="button" onClick={handleNewNote} className="px-3 py-1.5 text-sm rounded-lg bg-coral/10 text-coral hover:bg-coral/20 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral">+ {t(activeFolder ? "editor.newNote" : "editor.newFolder")}</button>
             </div>
           )}
         </main>

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -335,6 +335,7 @@ export const en = {
   "editor.noFolders": "No folders.",
   "editor.newFolder": "New folder",
   "editor.selectOrCreate": "Select a note, or create one.",
+  "editor.createFolderFirst": "Create a folder to start saving notes.",
   "editor.newNote": "New note",
   "editor.lockedNoteUnsupported": "Locked notes cannot be edited here yet. Use Browse Notes to open them securely.",
   "postit.lockedPinBlocked": "Unlock this note before pinning it. Pinned notes are stored without encryption.",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -336,6 +336,7 @@ export const zhCN: Translations = {
   "editor.noFolders": "没有文件夹。",
   "editor.newFolder": "新建文件夹",
   "editor.selectOrCreate": "选择一条笔记，或新建一条。",
+  "editor.createFolderFirst": "创建文件夹以开始保存笔记。",
   "editor.newNote": "新建笔记",
   "editor.lockedNoteUnsupported": "此处暂不支持编辑已锁定的笔记。请使用“浏览笔记”安全地打开它们。",
   "postit.lockedPinBlocked": "请先解除此笔记的锁定再固定。固定的笔记以未加密形式存储。",


### PR DESCRIPTION
## Summary
Fixes #109. Both New note entry points now open the existing explicit folder-name input when no folder is active. The empty state explains the prerequisite and offers New folder. Existing-vault saves are unchanged; startup/settings and Escape cancellation never recreate Inbox or another default folder (preserves #14/#17).

## Verification
- Three new behavioral checks failed before the fix; all 24 persistence tests pass after it. Independent review ran both editor suites: 26/26 passed.
- Full ./scripts/verify.sh passed 444 tests (255 frontend, 138 Rust unit, 8 Rust integration, 43 Swift), plus formatting, strict Clippy, build/platform/bundle gates; one pre-existing ignored benchmark. 34 seconds locally.
- Native macOS 27 arm64 QA: toolbar opens and focuses folder field; typing then Escape creates no folder; Tab/Return activates the empty-state action; Enter creates the chosen notebook; the first note is editable and its exact Markdown is on disk under that notebook. No personal notes or account permissions used.
- English and Simplified Chinese guidance; no dependency or release version change.

## Limitations
One initial launch immediately after rebuilding produced a blank WebKit window despite native startup completing. Reconnecting automation did not resolve it; quitting and starting the identical binary with the identical profile did, after which the above native tests passed. Cause is not established and this is not a general crash-free or release-readiness claim. No signing/notarization, real-account OS integrations or updater acceptance was exercised.

CI must pass on this exact PR before merge. Independent agent review found no blockers but is not a GitHub approving review; the previous admin authorization applied specifically to #108.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Creating a note with no folders now prompts you to create a folder instead of doing nothing.
  - The empty editor state explains that a folder is required before saving notes.
  - Cancelling folder setup no longer creates default folders or saves a note.

- **Localization**
  - Added the new empty-state guidance in English and Simplified Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->